### PR TITLE
[codex] add minimal GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # telemetry-lab
 
+[![CI](https://github.com/stacknil/telemetry-lab/actions/workflows/ci.yml/badge.svg)](https://github.com/stacknil/telemetry-lab/actions/workflows/ci.yml)
+
 Small prototypes for telemetry analytics, monitoring, and detection-oriented signal processing.
 
 ## Current demo


### PR DESCRIPTION
## Summary
This PR adds a minimal GitHub Actions CI workflow for the repository so every push and pull request runs the existing pytest suite automatically. It also adds a small README badge that points at the stable `CI` workflow.

Before this change, the telemetry-window-demo prototype had local tests but no repository-level automation to catch regressions in time parsing, sliding-window behavior, or rule-based alert logic when changes landed in GitHub. The underlying issue was simply missing CI wiring rather than a code defect.

The fix keeps scope intentionally small for a portfolio prototype:
- add `.github/workflows/ci.yml`
- trigger on `push` and `pull_request`
- run one `test` job on `ubuntu-latest`
- use `actions/setup-python@v5` with Python `3.11`
- upgrade pip, install the project with dev dependencies via `python -m pip install -e ".[dev]"`
- run `pytest`
- avoid deployment, release, and packaging steps

## Validation
- `pytest`
