### PR TITLE
docs: sync latest milestone to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Small portfolio prototypes for telemetry analytics, monitoring, and detection-oriented signal processing.
 
-Latest milestone: [v0.5.0 — third demo and three-demo structure](https://github.com/stacknil/telemetry-lab/releases/latest).
+Latest milestone: [v0.6.0 — fourth demo and config-change investigation](https://github.com/stacknil/telemetry-lab/releases/latest).
 
 ## Demos
 


### PR DESCRIPTION
## Summary
- update the README \\Latest milestone\\ entry from \\0.5.0\\ to \\0.6.0\\
- keep the public landing page aligned with the already published \\0.6.0\\ release

## Notes
- docs-only
- no runtime, validation, or guardrail changes
