### PR TITLE
Improve CLI error reporting

### DIFF
--- a/src/telemetry_window_demo/cli.py
+++ b/src/telemetry_window_demo/cli.py
@@ -42,10 +42,13 @@ RUN_RULE_CONFIG_FIELDS = {
 }
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     parser = build_parser()
-    args = parser.parse_args()
-    args.func(args)
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except (OSError, ValueError) as exc:
+        parser.exit(status=1, message=f"error: {exc}\n")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/telemetry_window_demo/io.py
+++ b/src/telemetry_window_demo/io.py
@@ -12,8 +12,13 @@ from .schema import validate_event_frame
 
 def load_config(path: str | Path) -> dict[str, Any]:
     config_path = Path(path)
-    with config_path.open("r", encoding="utf-8") as handle:
-        config = yaml.safe_load(handle) or {}
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Invalid YAML config in {config_path}: {exc}") from exc
     if not isinstance(config, dict):
         raise ValueError("Configuration must deserialize to a mapping.")
     return config

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from telemetry_window_demo.cli import main
+
+
+def test_main_reports_config_errors_without_traceback(tmp_path, capsys) -> None:
+    config_path = tmp_path / "missing-input-path.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"output_dir": str(tmp_path / "processed")}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["run", "--config", str(config_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "input_path" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_main_reports_missing_config_without_traceback(tmp_path, capsys) -> None:
+    config_path = tmp_path / "missing.yaml"
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["run", "--config", str(config_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "Config file not found" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_main_reports_invalid_yaml_config_without_traceback(tmp_path, capsys) -> None:
+    config_path = tmp_path / "broken.yaml"
+    config_path.write_text("input_path: [\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["run", "--config", str(config_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "Invalid YAML config" in stderr
+    assert "Traceback" not in stderr


### PR DESCRIPTION
## Summary
- make the CLI convert common configuration and file errors into concise error output without a Python traceback
- report missing config files and invalid YAML configs with clearer messages
- add CLI-level regression tests for friendly error handling

## Tests
- pytest
- python -m telemetry_window_demo.cli run --config does-not-exist.yaml
- python -m telemetry_window_demo.cli run --config configs/default.yaml