### PR TITLE
Validate output table inputs

### DIFF
--- a/src/telemetry_window_demo/io.py
+++ b/src/telemetry_window_demo/io.py
@@ -9,6 +9,22 @@ import yaml
 
 from .schema import validate_event_frame
 
+FEATURE_TABLE_REQUIRED_COLUMNS = (
+    "window_start",
+    "window_end",
+    "event_count",
+    "error_rate",
+)
+FEATURE_TABLE_DATETIME_COLUMNS = ("window_start", "window_end")
+ALERT_TABLE_REQUIRED_COLUMNS = (
+    "alert_time",
+    "window_start",
+    "window_end",
+    "rule_name",
+    "severity",
+)
+ALERT_TABLE_DATETIME_COLUMNS = ("alert_time", "window_start", "window_end")
+
 
 def load_config(path: str | Path) -> dict[str, Any]:
     config_path = Path(path)
@@ -32,7 +48,6 @@ def resolve_config_path(config_path: str | Path, value: str | Path) -> Path:
     if base_dir.name == "configs":
         base_dir = base_dir.parent
     return (base_dir / candidate).resolve()
-
 
 
 def load_events(path: str | Path) -> pd.DataFrame:
@@ -77,14 +92,60 @@ def load_events(path: str | Path) -> pd.DataFrame:
 
 
 def load_feature_table(path: str | Path) -> pd.DataFrame:
-    return pd.read_csv(path, parse_dates=["window_start", "window_end"])
+    table_path = Path(path)
+    frame = pd.read_csv(table_path)
+    _require_columns(frame, FEATURE_TABLE_REQUIRED_COLUMNS, source=str(table_path))
+    _parse_datetime_columns(
+        frame,
+        FEATURE_TABLE_DATETIME_COLUMNS,
+        source=str(table_path),
+    )
+    return frame
 
 
 def load_alert_table(path: str | Path) -> pd.DataFrame:
-    return pd.read_csv(
-        path,
-        parse_dates=["alert_time", "window_start", "window_end"],
+    table_path = Path(path)
+    frame = pd.read_csv(table_path)
+    _require_columns(frame, ALERT_TABLE_REQUIRED_COLUMNS, source=str(table_path))
+    _parse_datetime_columns(
+        frame,
+        ALERT_TABLE_DATETIME_COLUMNS,
+        source=str(table_path),
     )
+    return frame
+
+
+def _require_columns(
+    frame: pd.DataFrame,
+    required_columns: tuple[str, ...],
+    *,
+    source: str,
+) -> None:
+    missing_columns = [
+        column for column in required_columns if column not in frame.columns
+    ]
+    if missing_columns:
+        raise ValueError(
+            f"Missing required columns in {source}: " + ", ".join(missing_columns)
+        )
+
+
+def _parse_datetime_columns(
+    frame: pd.DataFrame,
+    datetime_columns: tuple[str, ...],
+    *,
+    source: str,
+) -> None:
+    for column in datetime_columns:
+        try:
+            parsed = pd.to_datetime(frame[column], utc=True, errors="raise")
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid datetime values in {source}: {column}"
+            ) from exc
+        if parsed.isna().any():
+            raise ValueError(f"Missing datetime values in {source}: {column}")
+        frame[column] = parsed
 
 
 def write_table(frame: pd.DataFrame, path: str | Path) -> Path:

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -48,3 +48,21 @@ def test_main_reports_invalid_yaml_config_without_traceback(tmp_path, capsys) ->
     assert stderr.startswith("error: ")
     assert "Invalid YAML config" in stderr
     assert "Traceback" not in stderr
+
+
+def test_main_reports_bad_plot_feature_table_without_traceback(tmp_path, capsys) -> None:
+    features_path = tmp_path / "features.csv"
+    features_path.write_text(
+        "window_start,window_end,error_rate\n"
+        "2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,0.25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["plot", "--features", str(features_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "event_count" in stderr
+    assert "Traceback" not in stderr

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,27 @@ from __future__ import annotations
 
 import pytest
 
-from telemetry_window_demo.io import load_events
+from telemetry_window_demo.io import (
+    load_alert_table,
+    load_config,
+    load_events,
+    load_feature_table,
+)
+
+
+def test_load_config_reports_missing_file(tmp_path) -> None:
+    path = tmp_path / "missing.yaml"
+
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
+        load_config(path)
+
+
+def test_load_config_rejects_invalid_yaml(tmp_path) -> None:
+    path = tmp_path / "broken.yaml"
+    path.write_text("input_path: [\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid YAML config"):
+        load_config(path)
 
 
 def test_load_events_from_jsonl(tmp_path) -> None:
@@ -138,4 +158,68 @@ def test_load_events_rejects_missing_required_values(filename, content, tmp_path
     message = str(excinfo.value)
     assert "Missing required event values" in message
     assert "target (1 row(s))" in message
+
+
+def test_load_feature_table_requires_plot_columns(tmp_path) -> None:
+    path = tmp_path / "features.csv"
+    path.write_text(
+        "window_start,window_end,error_rate\n"
+        "2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,0.25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_feature_table(path)
+
+    message = str(excinfo.value)
+    assert "Missing required columns" in message
+    assert "event_count" in message
+
+
+def test_load_feature_table_rejects_invalid_window_timestamp(tmp_path) -> None:
+    path = tmp_path / "features.csv"
+    path.write_text(
+        "window_start,window_end,event_count,error_rate\n"
+        "not-a-time,2026-03-10T10:01:00Z,10,0.25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_feature_table(path)
+
+    message = str(excinfo.value)
+    assert "Invalid datetime values" in message
+    assert "window_start" in message
+
+
+def test_load_alert_table_requires_plot_columns(tmp_path) -> None:
+    path = tmp_path / "alerts.csv"
+    path.write_text(
+        "alert_time,window_start,window_end,severity\n"
+        "2026-03-10T10:01:00Z,2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,high\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_alert_table(path)
+
+    message = str(excinfo.value)
+    assert "Missing required columns" in message
+    assert "rule_name" in message
+
+
+def test_load_alert_table_rejects_missing_alert_timestamp(tmp_path) -> None:
+    path = tmp_path / "alerts.csv"
+    path.write_text(
+        "alert_time,window_start,window_end,rule_name,severity\n"
+        ",2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,high_error_rate,medium\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_alert_table(path)
+
+    message = str(excinfo.value)
+    assert "Missing datetime values" in message
+    assert "alert_time" in message
 


### PR DESCRIPTION
## Summary
- validate loaded feature and alert CSV tables before plotting
- report missing output-table columns and invalid/missing datetime values as clear ValueErrors
- add IO and CLI regression tests for bad plot inputs

## Tests
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml
- python -m telemetry_window_demo.cli plot --features <bad features csv>