### PR TITLE
Validate output table values

### DIFF
--- a/src/telemetry_window_demo/io.py
+++ b/src/telemetry_window_demo/io.py
@@ -16,6 +16,10 @@ FEATURE_TABLE_REQUIRED_COLUMNS = (
     "error_rate",
 )
 FEATURE_TABLE_DATETIME_COLUMNS = ("window_start", "window_end")
+FEATURE_TABLE_NUMERIC_COLUMNS = (
+    ("event_count", 0.0, None, True),
+    ("error_rate", 0.0, 1.0, False),
+)
 ALERT_TABLE_REQUIRED_COLUMNS = (
     "alert_time",
     "window_start",
@@ -24,6 +28,7 @@ ALERT_TABLE_REQUIRED_COLUMNS = (
     "severity",
 )
 ALERT_TABLE_DATETIME_COLUMNS = ("alert_time", "window_start", "window_end")
+ALERT_TABLE_TEXT_COLUMNS = ("rule_name", "severity")
 
 
 def load_config(path: str | Path) -> dict[str, Any]:
@@ -100,6 +105,11 @@ def load_feature_table(path: str | Path) -> pd.DataFrame:
         FEATURE_TABLE_DATETIME_COLUMNS,
         source=str(table_path),
     )
+    _parse_numeric_columns(
+        frame,
+        FEATURE_TABLE_NUMERIC_COLUMNS,
+        source=str(table_path),
+    )
     return frame
 
 
@@ -112,6 +122,7 @@ def load_alert_table(path: str | Path) -> pd.DataFrame:
         ALERT_TABLE_DATETIME_COLUMNS,
         source=str(table_path),
     )
+    _require_text_columns(frame, ALERT_TABLE_TEXT_COLUMNS, source=str(table_path))
     return frame
 
 
@@ -160,6 +171,52 @@ def _parse_datetime_columns(
         if parsed.isna().any():
             raise ValueError(f"Missing datetime values in {source}: {column}")
         frame[column] = parsed
+
+
+def _parse_numeric_columns(
+    frame: pd.DataFrame,
+    numeric_columns: tuple[tuple[str, float, float | None, bool], ...],
+    *,
+    source: str,
+) -> None:
+    for column, minimum, maximum, require_integer in numeric_columns:
+        try:
+            parsed = pd.to_numeric(frame[column], errors="raise")
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid numeric values in {source}: {column}"
+            ) from exc
+
+        if parsed.isna().any():
+            raise ValueError(f"Missing numeric values in {source}: {column}")
+        if (parsed < minimum).any():
+            raise ValueError(
+                f"Numeric values in {source} must be at least {minimum:g}: {column}"
+            )
+        if maximum is not None and (parsed > maximum).any():
+            raise ValueError(
+                f"Numeric values in {source} must be at most {maximum:g}: {column}"
+            )
+        if require_integer and not (parsed % 1 == 0).all():
+            raise ValueError(
+                f"Numeric values in {source} must be whole numbers: {column}"
+            )
+
+        frame[column] = parsed.astype("int64" if require_integer else "float64")
+
+
+def _require_text_columns(
+    frame: pd.DataFrame,
+    text_columns: tuple[str, ...],
+    *,
+    source: str,
+) -> None:
+    for column in text_columns:
+        empty_values = (
+            frame[column].isna() | frame[column].astype(str).str.strip().eq("")
+        )
+        if empty_values.any():
+            raise ValueError(f"Missing text values in {source}: {column}")
 
 
 def write_table(frame: pd.DataFrame, path: str | Path) -> Path:

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -68,6 +68,25 @@ def test_main_reports_bad_plot_feature_table_without_traceback(tmp_path, capsys)
     assert "Traceback" not in stderr
 
 
+def test_main_reports_bad_plot_feature_value_without_traceback(tmp_path, capsys) -> None:
+    features_path = tmp_path / "features.csv"
+    features_path.write_text(
+        "window_start,window_end,event_count,error_rate\n"
+        "2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,not-a-count,0.25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["plot", "--features", str(features_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "Invalid numeric values" in stderr
+    assert "event_count" in stderr
+    assert "Traceback" not in stderr
+
+
 def test_main_reports_missing_default_alert_table_without_traceback(tmp_path, capsys) -> None:
     features_path = tmp_path / "features.csv"
     features_path.write_text(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -199,6 +199,38 @@ def test_load_feature_table_rejects_invalid_window_timestamp(tmp_path) -> None:
     assert "window_start" in message
 
 
+def test_load_feature_table_rejects_invalid_numeric_value(tmp_path) -> None:
+    path = tmp_path / "features.csv"
+    path.write_text(
+        "window_start,window_end,event_count,error_rate\n"
+        "2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,not-a-count,0.25\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_feature_table(path)
+
+    message = str(excinfo.value)
+    assert "Invalid numeric values" in message
+    assert "event_count" in message
+
+
+def test_load_feature_table_rejects_out_of_range_error_rate(tmp_path) -> None:
+    path = tmp_path / "features.csv"
+    path.write_text(
+        "window_start,window_end,event_count,error_rate\n"
+        "2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,10,1.5\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_feature_table(path)
+
+    message = str(excinfo.value)
+    assert "at most 1" in message
+    assert "error_rate" in message
+
+
 def test_load_alert_table_rejects_invalid_csv(tmp_path) -> None:
     path = tmp_path / "alerts.csv"
     path.write_text(
@@ -242,4 +274,20 @@ def test_load_alert_table_rejects_missing_alert_timestamp(tmp_path) -> None:
     message = str(excinfo.value)
     assert "Missing datetime values" in message
     assert "alert_time" in message
+
+
+def test_load_alert_table_rejects_missing_rule_name(tmp_path) -> None:
+    path = tmp_path / "alerts.csv"
+    path.write_text(
+        "alert_time,window_start,window_end,rule_name,severity\n"
+        "2026-03-10T10:01:00Z,2026-03-10T10:00:00Z,2026-03-10T10:01:00Z,,medium\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_alert_table(path)
+
+    message = str(excinfo.value)
+    assert "Missing text values" in message
+    assert "rule_name" in message
 


### PR DESCRIPTION
## Summary
- validate feature-table numeric values before plotting
- reject out-of-range error rates and non-integer event counts with clear errors
- validate required alert-table text values and add CLI coverage for bad plot feature values

## Tests
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml
- python -m telemetry_window_demo.cli plot --features <features csv with invalid event_count>