### PR TITLE
Validate readable input file paths

### DIFF
--- a/src/telemetry_window_demo/io.py
+++ b/src/telemetry_window_demo/io.py
@@ -33,8 +33,7 @@ ALERT_TABLE_TEXT_COLUMNS = ("rule_name", "severity")
 
 def load_config(path: str | Path) -> dict[str, Any]:
     config_path = Path(path)
-    if not config_path.exists():
-        raise FileNotFoundError(f"Config file not found: {config_path}")
+    _require_existing_file(config_path, display_name="Config file")
     try:
         with config_path.open("r", encoding="utf-8") as handle:
             config = yaml.safe_load(handle) or {}
@@ -57,8 +56,7 @@ def resolve_config_path(config_path: str | Path, value: str | Path) -> Path:
 
 def load_events(path: str | Path) -> pd.DataFrame:
     input_path = Path(path)
-    if not input_path.exists():
-        raise FileNotFoundError(f"Input file not found: {input_path}")
+    _require_existing_file(input_path, display_name="Input file")
 
     suffix = input_path.suffix.lower()
     if suffix == ".jsonl":
@@ -127,9 +125,8 @@ def load_alert_table(path: str | Path) -> pd.DataFrame:
 
 
 def _read_csv_table(table_path: Path, *, table_name: str) -> pd.DataFrame:
-    if not table_path.exists():
-        display_name = table_name[:1].upper() + table_name[1:]
-        raise FileNotFoundError(f"{display_name} not found: {table_path}")
+    display_name = table_name[:1].upper() + table_name[1:]
+    _require_existing_file(table_path, display_name=display_name)
     try:
         return pd.read_csv(table_path)
     except (
@@ -138,6 +135,13 @@ def _read_csv_table(table_path: Path, *, table_name: str) -> pd.DataFrame:
         UnicodeDecodeError,
     ) as exc:
         raise ValueError(f"Invalid {table_name} CSV in {table_path}: {exc}") from exc
+
+
+def _require_existing_file(file_path: Path, *, display_name: str) -> None:
+    if not file_path.exists():
+        raise FileNotFoundError(f"{display_name} not found: {file_path}")
+    if not file_path.is_file():
+        raise ValueError(f"{display_name} path is not a file: {file_path}")
 
 
 def _require_columns(

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -50,6 +50,28 @@ def test_main_reports_invalid_yaml_config_without_traceback(tmp_path, capsys) ->
     assert "Traceback" not in stderr
 
 
+def test_main_reports_directory_input_without_traceback(tmp_path, capsys) -> None:
+    config_path = tmp_path / "directory-input.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "input_path": str(tmp_path),
+                "output_dir": str(tmp_path / "processed"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["run", "--config", str(config_path)])
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert stderr.startswith("error: ")
+    assert "Input file path is not a file" in stderr
+    assert "Traceback" not in stderr
+
+
 def test_main_reports_bad_plot_feature_table_without_traceback(tmp_path, capsys) -> None:
     features_path = tmp_path / "features.csv"
     features_path.write_text(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -17,6 +17,11 @@ def test_load_config_reports_missing_file(tmp_path) -> None:
         load_config(path)
 
 
+def test_load_config_rejects_directory_path(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Config file path is not a file"):
+        load_config(tmp_path)
+
+
 def test_load_config_rejects_invalid_yaml(tmp_path) -> None:
     path = tmp_path / "broken.yaml"
     path.write_text("input_path: [\n", encoding="utf-8")
@@ -68,6 +73,11 @@ def test_load_events_from_csv_preserves_na_like_required_values(tmp_path) -> Non
 
     assert len(frame) == 2
     assert list(frame["target"]) == ["NA", "null"]
+
+
+def test_load_events_rejects_directory_path(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Input file path is not a file"):
+        load_events(tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -183,6 +193,11 @@ def test_load_feature_table_reports_missing_file(tmp_path) -> None:
         load_feature_table(path)
 
 
+def test_load_feature_table_rejects_directory_path(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Feature table path is not a file"):
+        load_feature_table(tmp_path)
+
+
 def test_load_feature_table_rejects_invalid_window_timestamp(tmp_path) -> None:
     path = tmp_path / "features.csv"
     path.write_text(
@@ -242,6 +257,11 @@ def test_load_alert_table_rejects_invalid_csv(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Invalid alert table CSV"):
         load_alert_table(path)
+
+
+def test_load_alert_table_rejects_directory_path(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Alert table path is not a file"):
+        load_alert_table(tmp_path)
 
 
 def test_load_alert_table_requires_plot_columns(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add a shared file-path guard for config, event, feature, and alert inputs
- report directory paths as clear user errors before parsing
- cover direct loader and CLI directory-input failures

## Tests
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml