### PR TITLE
Honor configured event timestamp column

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Runtime input support:
 
 Required fields for both formats on every row or record:
 
-- `timestamp`
+- `timestamp` by default, or the column named by `time.timestamp_col` in a run config
 - `event_type`
 - `source`
 - `target`

--- a/src/telemetry_window_demo/cli.py
+++ b/src/telemetry_window_demo/cli.py
@@ -121,17 +121,18 @@ def run_command(args: argparse.Namespace) -> None:
     rules_config = run_config["rules"]
     input_path = resolve_config_path(config_path, run_config["input_path"])
     output_dir = resolve_config_path(config_path, run_config["output_dir"])
+    timestamp_col = time_config["timestamp_col"]
 
-    events = load_events(input_path)
+    events = load_events(input_path, timestamp_col=timestamp_col)
     normalized = normalize_events(
         events,
-        timestamp_col=time_config.get("timestamp_col", "timestamp"),
+        timestamp_col=timestamp_col,
         error_statuses=feature_config.get("error_statuses"),
         high_severity_levels=feature_config.get("severity_levels"),
     )
     windows = build_windows(
         normalized,
-        timestamp_col=time_config.get("timestamp_col", "timestamp"),
+        timestamp_col=timestamp_col,
         window_size_seconds=time_config["window_size_seconds"],
         step_size_seconds=time_config["step_size_seconds"],
     )

--- a/src/telemetry_window_demo/io.py
+++ b/src/telemetry_window_demo/io.py
@@ -54,7 +54,7 @@ def resolve_config_path(config_path: str | Path, value: str | Path) -> Path:
     return (base_dir / candidate).resolve()
 
 
-def load_events(path: str | Path) -> pd.DataFrame:
+def load_events(path: str | Path, *, timestamp_col: str = "timestamp") -> pd.DataFrame:
     input_path = Path(path)
     _require_existing_file(input_path, display_name="Input file")
 
@@ -90,7 +90,7 @@ def load_events(path: str | Path) -> pd.DataFrame:
     else:
         raise ValueError("Unsupported input format. Use .jsonl or .csv.")
 
-    validate_event_frame(events, source=str(input_path))
+    validate_event_frame(events, source=str(input_path), timestamp_col=timestamp_col)
     return events
 
 

--- a/src/telemetry_window_demo/schema.py
+++ b/src/telemetry_window_demo/schema.py
@@ -4,7 +4,9 @@ import re
 
 import pandas as pd
 
-REQUIRED_COLUMNS = ("timestamp", "event_type", "source", "target", "status")
+DEFAULT_TIMESTAMP_COLUMN = "timestamp"
+REQUIRED_EVENT_COLUMNS = ("event_type", "source", "target", "status")
+REQUIRED_COLUMNS = (DEFAULT_TIMESTAMP_COLUMN, *REQUIRED_EVENT_COLUMNS)
 RECOMMENDED_COLUMNS = ("user", "host", "ip", "severity")
 OPTIONAL_COLUMNS = RECOMMENDED_COLUMNS + ("metadata",)
 
@@ -12,16 +14,23 @@ DEFAULT_ERROR_STATUSES = ("fail", "blocked", "error")
 DEFAULT_HIGH_SEVERITY_LEVELS = ("high", "critical")
 
 
-def validate_event_frame(events: pd.DataFrame, source: str | None = None) -> None:
+def validate_event_frame(
+    events: pd.DataFrame,
+    source: str | None = None,
+    timestamp_col: str = DEFAULT_TIMESTAMP_COLUMN,
+) -> None:
+    if not isinstance(timestamp_col, str) or not timestamp_col.strip():
+        raise ValueError("Timestamp column name must be a non-empty string.")
+    required_columns = (timestamp_col.strip(), *REQUIRED_EVENT_COLUMNS)
     location = f" in {source}" if source else ""
-    missing = [column for column in REQUIRED_COLUMNS if column not in events.columns]
+    missing = [column for column in required_columns if column not in events.columns]
     if missing:
         raise ValueError(
             f"Missing required event fields{location}: {', '.join(missing)}"
         )
 
     missing_values: list[str] = []
-    for column in REQUIRED_COLUMNS:
+    for column in required_columns:
         values = events[column]
         missing_mask = values.isna()
         blank_mask = values.astype("string").str.strip().eq("").fillna(False)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -75,6 +75,38 @@ def test_load_events_from_csv_preserves_na_like_required_values(tmp_path) -> Non
     assert list(frame["target"]) == ["NA", "null"]
 
 
+@pytest.mark.parametrize(
+    ("filename", "content"),
+    [
+        (
+            "events.jsonl",
+            (
+                '{"event_time":"2026-03-10T10:00:00Z","event_type":"login_success",'
+                '"source":"user_a","target":"auth","status":"ok"}\n'
+            ),
+        ),
+        (
+            "events.csv",
+            "event_time,event_type,source,target,status\n"
+            "2026-03-10T10:00:00Z,login_success,user_a,auth,ok\n",
+        ),
+    ],
+)
+def test_load_events_allows_configured_timestamp_column(
+    filename,
+    content,
+    tmp_path,
+) -> None:
+    path = tmp_path / filename
+    path.write_text(content, encoding="utf-8")
+
+    frame = load_events(path, timestamp_col="event_time")
+
+    assert len(frame) == 1
+    assert "timestamp" not in frame.columns
+    assert frame.loc[0, "event_time"] == "2026-03-10T10:00:00Z"
+
+
 def test_load_events_rejects_directory_path(tmp_path) -> None:
     with pytest.raises(ValueError, match="Input file path is not a file"):
         load_events(tmp_path)

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -178,3 +178,38 @@ def test_pipeline_writes_summary_when_rules_are_null(tmp_path, capsys) -> None:
 
     stdout = capsys.readouterr().out
     assert "[OK] Loaded 41 events" in stdout
+
+
+def test_pipeline_honors_configured_timestamp_column(tmp_path, capsys) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config = load_config(repo_root / "configs" / "default.yaml")
+    generated_output_dir = tmp_path / "custom_time"
+    input_path = tmp_path / "custom_time_events.csv"
+    input_path.write_text(
+        "event_time,event_type,source,target,status,severity\n"
+        "2026-03-10T10:00:00Z,login_fail,user_a,auth,fail,high\n"
+        "2026-03-10T10:00:10Z,login_success,user_a,auth,ok,low\n",
+        encoding="utf-8",
+    )
+    config["input_path"] = str(input_path.resolve())
+    config["output_dir"] = str(generated_output_dir.resolve())
+    config["time"]["timestamp_col"] = "event_time"
+
+    temp_config_path = tmp_path / "custom_time.yaml"
+    temp_config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    run_command(Namespace(config=str(temp_config_path)))
+
+    generated_features = load_feature_table(generated_output_dir / "features.csv")
+    generated_summary = _load_summary(generated_output_dir / "summary.json")
+
+    assert len(generated_features) == 2
+    assert generated_features.loc[0, "event_count"] == 2
+    assert generated_summary["normalized_event_count"] == 2
+    assert generated_summary["window_count"] == 2
+
+    stdout = capsys.readouterr().out
+    assert "[OK] Loaded 2 events" in stdout


### PR DESCRIPTION
## Summary
- let event loading validate the configured timestamp column instead of always requiring timestamp
- pass time.timestamp_col through the run pipeline before normalization/windowing
- add direct loader and E2E coverage for custom time columns and update README input docs

## Tests
- pytest tests/test_io.py tests/test_pipeline_e2e.py tests/test_run_config_validation.py
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml