### PR TITLE
Reject timestamp column field collisions

### DIFF
--- a/src/telemetry_window_demo/cli.py
+++ b/src/telemetry_window_demo/cli.py
@@ -19,6 +19,7 @@ from .io import (
 )
 from .preprocess import normalize_events
 from .rules import apply_rules
+from .schema import DEFAULT_TIMESTAMP_COLUMN, REQUIRED_EVENT_COLUMNS
 from .visualize import plot_outputs
 from .windowing import build_windows
 
@@ -269,7 +270,7 @@ def _validate_run_config(config: Mapping[str, Any]) -> dict[str, Any]:
             "output_dir",
         ),
         "time": {
-            "timestamp_col": _string_config_value(
+            "timestamp_col": _timestamp_column_config_value(
                 time_config.get("timestamp_col", "timestamp"),
                 "time.timestamp_col",
             ),
@@ -438,6 +439,19 @@ def _string_config_value(value: Any, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"Config field '{field_name}' must be a non-empty string.")
     return value.strip()
+
+
+def _timestamp_column_config_value(value: Any, field_name: str) -> str:
+    timestamp_col = _string_config_value(value, field_name)
+    if (
+        timestamp_col != DEFAULT_TIMESTAMP_COLUMN
+        and timestamp_col in REQUIRED_EVENT_COLUMNS
+    ):
+        raise ValueError(
+            f"Config field '{field_name}' must not reuse an event field name: "
+            f"{timestamp_col}."
+        )
+    return timestamp_col
 
 
 def _int_config_value(value: Any, field_name: str, *, minimum: int) -> int:

--- a/src/telemetry_window_demo/schema.py
+++ b/src/telemetry_window_demo/schema.py
@@ -21,7 +21,14 @@ def validate_event_frame(
 ) -> None:
     if not isinstance(timestamp_col, str) or not timestamp_col.strip():
         raise ValueError("Timestamp column name must be a non-empty string.")
-    required_columns = (timestamp_col.strip(), *REQUIRED_EVENT_COLUMNS)
+    timestamp_column = timestamp_col.strip()
+    if timestamp_column in REQUIRED_EVENT_COLUMNS:
+        raise ValueError(
+            "Timestamp column must not reuse an event field name: "
+            f"{timestamp_column}"
+        )
+
+    required_columns = (timestamp_column, *REQUIRED_EVENT_COLUMNS)
     location = f" in {source}" if source else ""
     missing = [column for column in required_columns if column not in events.columns]
     if missing:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -107,6 +107,22 @@ def test_load_events_allows_configured_timestamp_column(
     assert frame.loc[0, "event_time"] == "2026-03-10T10:00:00Z"
 
 
+def test_load_events_rejects_timestamp_column_that_reuses_event_field(tmp_path) -> None:
+    path = tmp_path / "events.csv"
+    path.write_text(
+        "event_type,source,target,status\n"
+        "2026-03-10T10:00:00Z,user_a,auth,ok\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        load_events(path, timestamp_col="event_type")
+
+    message = str(excinfo.value)
+    assert "Timestamp column must not reuse an event field name" in message
+    assert "event_type" in message
+
+
 def test_load_events_rejects_directory_path(tmp_path) -> None:
     with pytest.raises(ValueError, match="Input file path is not a file"):
         load_events(tmp_path)

--- a/tests/test_run_config_validation.py
+++ b/tests/test_run_config_validation.py
@@ -55,6 +55,15 @@ def test_run_config_rejects_non_positive_step_size(tmp_path) -> None:
         run_command(Namespace(config=str(config_path)))
 
 
+def test_run_config_rejects_timestamp_column_event_field_collision(tmp_path) -> None:
+    config = _base_config(tmp_path)
+    config["time"]["timestamp_col"] = "event_type"
+    config_path = _write_config(tmp_path, config)
+
+    with pytest.raises(ValueError, match="time.timestamp_col"):
+        run_command(Namespace(config=str(config_path)))
+
+
 def test_run_config_rejects_string_feature_list(tmp_path) -> None:
     config = _base_config(tmp_path)
     config["features"]["count_event_types"] = "login_fail"


### PR DESCRIPTION
## Summary
- reject configured timestamp columns that reuse required event field names
- surface the collision early as a time.timestamp_col config error in run configs
- add loader and run-config regression coverage for timestamp/event field collisions

## Tests
- pytest tests/test_io.py tests/test_run_config_validation.py tests/test_pipeline_e2e.py
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml