### PR TITLE
Refresh validation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Required fields for both formats on every row or record:
 - `target`
 - `status`
 
+Input and output validation:
+
+- config paths, event inputs, and plot CSV inputs must point to files
+- required event fields must be present and non-empty
+- custom timestamp columns cannot reuse required event field names
+- plot input tables validate required columns, datetime values, numeric ranges, and window bounds
+
 Cooldown behavior:
 
 - repeated alerts are keyed by `(rule_name, scope)`
@@ -125,8 +132,8 @@ Cooldown behavior:
 
 ## Next Demo Directions
 
-- strengthen JSONL and CSV validation so ingestion failures are clearer
-- keep reducing repeated alert noise while preserving simple rule-based behavior
+- add a focused auth/login anomaly triage walkthrough on top of the existing window features
+- add a compact config-change drift follow-up scenario using the current deterministic evidence model
 - keep sample-output docs and public repo presentation aligned with the checked-in demo state
 
 ## Scope

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ Recently added:
 
 - [rule-evaluation-and-dedup-demo](../demos/rule-evaluation-and-dedup-demo/README.md) now shows raw rule hits, retained alerts, and suppression reasons side by side.
 - [config-change-investigation-demo](../demos/config-change-investigation-demo/README.md) now shows risky configuration changes, bounded evidence attachment, and deterministic investigation summaries.
+- Core telemetry-window validation now gives clearer failures for malformed inputs, invalid run configs, rule parameters, plot CSV values, and output window bounds.
 
 ## 1. Auth/Login Anomaly Triage Demo
 

--- a/docs/sample-output.md
+++ b/docs/sample-output.md
@@ -1,6 +1,7 @@
 # Sample Output
 
 The committed sample artifacts are intended to be reproducible from the bundled inputs and configs.
+The CLI validates plot CSV inputs before rendering: required columns must be present, timestamps must parse, counts and rates must stay in range, and each output row must have coherent window bounds.
 
 ## Default Sample
 


### PR DESCRIPTION
## Summary
- document current input and output validation behavior in README
- update Next Demo Directions now that validation hardening has landed
- note current plot CSV validation in sample-output docs and roadmap

## Tests
- pytest
- python -m telemetry_window_demo.cli run --config configs/default.yaml