### PR TITLE
Freeze reviewer artifact contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Cooldown behavior:
 
 - [`demos/rule-evaluation-and-dedup-demo/README.md`](demos/rule-evaluation-and-dedup-demo/README.md) explains the third demo and links its committed before/after dedup artifacts
 - [`demos/config-change-investigation-demo/README.md`](demos/config-change-investigation-demo/README.md) explains the config-change investigation demo and its committed artifacts
-- [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack
+- [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
 - [`docs/reviewer-path.md`](docs/reviewer-path.md) maps common review questions to the right demo and artifacts
 - [`docs/architecture.md`](docs/architecture.md) diagrams the local file-based detection workflow
 - [`docs/sample-output.md`](docs/sample-output.md) summarizes the committed sample artifacts

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -36,6 +36,16 @@ The current artifact names are reviewer-facing contracts for the v0.7 / v1.0 con
 - If an artifact must be renamed, update the README, reviewer path, this reviewer pack, demo README, tests, and committed sample outputs in the same change.
 - Do not introduce platform-style names that imply alert routing, case management, real-time ingestion, or autonomous response.
 
+### Stable Reviewer-Visible Artifacts
+
+| Area | Stable artifact paths |
+| --- | --- |
+| Default telemetry sample | `data/processed/features.csv`, `data/processed/alerts.csv`, `data/processed/summary.json`, `data/processed/event_count_timeline.png`, `data/processed/error_rate_timeline.png`, `data/processed/alerts_timeline.png` |
+| Richer telemetry sample | `data/processed/richer_sample/features.csv`, `data/processed/richer_sample/alerts.csv`, `data/processed/richer_sample/summary.json`, `data/processed/richer_sample/event_count_timeline.png`, `data/processed/richer_sample/error_rate_timeline.png`, `data/processed/richer_sample/alerts_timeline.png` |
+| AI-assisted detection demo | `demos/ai-assisted-detection-demo/artifacts/rule_hits.json`, `demos/ai-assisted-detection-demo/artifacts/case_bundles.json`, `demos/ai-assisted-detection-demo/artifacts/case_summaries.json`, `demos/ai-assisted-detection-demo/artifacts/case_report.md`, `demos/ai-assisted-detection-demo/artifacts/audit_traces.jsonl` |
+| Rule dedup demo | `demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_before_dedup.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_after_dedup.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/dedup_report.md` |
+| Config-change investigation demo | `demos/config-change-investigation-demo/artifacts/change_events_normalized.json`, `demos/config-change-investigation-demo/artifacts/investigation_hits.json`, `demos/config-change-investigation-demo/artifacts/investigation_summary.json`, `demos/config-change-investigation-demo/artifacts/investigation_report.md` |
+
 ## Fast Verification
 
 From the repository root:

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -43,6 +43,34 @@ REVIEWER_DEMO_MATRIX = [
     ),
 ]
 
+STABLE_REVIEWER_ARTIFACTS = [
+    "data/processed/features.csv",
+    "data/processed/alerts.csv",
+    "data/processed/summary.json",
+    "data/processed/event_count_timeline.png",
+    "data/processed/error_rate_timeline.png",
+    "data/processed/alerts_timeline.png",
+    "data/processed/richer_sample/features.csv",
+    "data/processed/richer_sample/alerts.csv",
+    "data/processed/richer_sample/summary.json",
+    "data/processed/richer_sample/event_count_timeline.png",
+    "data/processed/richer_sample/error_rate_timeline.png",
+    "data/processed/richer_sample/alerts_timeline.png",
+    "demos/ai-assisted-detection-demo/artifacts/rule_hits.json",
+    "demos/ai-assisted-detection-demo/artifacts/case_bundles.json",
+    "demos/ai-assisted-detection-demo/artifacts/case_summaries.json",
+    "demos/ai-assisted-detection-demo/artifacts/case_report.md",
+    "demos/ai-assisted-detection-demo/artifacts/audit_traces.jsonl",
+    "demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_before_dedup.json",
+    "demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_after_dedup.json",
+    "demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json",
+    "demos/rule-evaluation-and-dedup-demo/artifacts/dedup_report.md",
+    "demos/config-change-investigation-demo/artifacts/change_events_normalized.json",
+    "demos/config-change-investigation-demo/artifacts/investigation_hits.json",
+    "demos/config-change-investigation-demo/artifacts/investigation_summary.json",
+    "demos/config-change-investigation-demo/artifacts/investigation_report.md",
+]
+
 
 def _read_repo_file(relative_path: str) -> str:
     return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
@@ -92,6 +120,15 @@ def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
         assert f"`{demo_name}`" in reviewer_pack
         for artifact_path in artifact_paths:
             assert f"`{artifact_path}`" in reviewer_pack
+
+
+def test_reviewer_pack_freezes_stable_artifact_names() -> None:
+    reviewer_pack = _read_repo_file("docs/reviewer-pack.md")
+
+    assert "Stable Reviewer-Visible Artifacts" in reviewer_pack
+    for artifact_path in STABLE_REVIEWER_ARTIFACTS:
+        assert f"`{artifact_path}`" in reviewer_pack
+        assert (REPO_ROOT / artifact_path).is_file(), artifact_path
 
 
 def test_architecture_doc_keeps_local_file_based_boundaries() -> None:


### PR DESCRIPTION
## Summary
- Expands the reviewer pack artifact naming contract into an explicit stable artifact table
- Marks the reviewer pack as the artifact naming contract from README
- Adds reviewer-doc regression coverage for every stable reviewer-visible artifact path

## Validation
- pytest tests/test_reviewer_docs.py --basetemp .pytest-artifacts-artifact-contract
- pytest --basetemp .pytest-artifacts-full-20260526-1
- git diff --cached --check