### PR TITLE
Add v1 reviewer readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Cooldown behavior:
 - stabilize the four-demo matrix and avoid broad platform expansion
 - freeze reviewer-visible artifact names unless a rename is intentionally coordinated across docs, tests, and sample outputs
 - use [`docs/reviewer-pack.md`](docs/reviewer-pack.md) and [`docs/architecture.md`](docs/architecture.md) as the consolidation entrypoints
+- use the [`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate) before treating the repo as consolidated
 - add at most one more demo before v1-style consolidation
 
 ## Scope

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -46,6 +46,17 @@ The current artifact names are reviewer-facing contracts for the v0.7 / v1.0 con
 | Rule dedup demo | `demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_before_dedup.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/rule_hits_after_dedup.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json`, `demos/rule-evaluation-and-dedup-demo/artifacts/dedup_report.md` |
 | Config-change investigation demo | `demos/config-change-investigation-demo/artifacts/change_events_normalized.json`, `demos/config-change-investigation-demo/artifacts/investigation_hits.json`, `demos/config-change-investigation-demo/artifacts/investigation_summary.json`, `demos/config-change-investigation-demo/artifacts/investigation_report.md` |
 
+## v1 Readiness Gate
+
+Before treating the repo as v1-style consolidated:
+
+- Keep the four-demo matrix stable, or document any intentional retirement in the README, reviewer path, reviewer pack, roadmap, and tests.
+- Keep reviewer-visible artifact names stable, or update the artifact naming contract and committed sample outputs in the same change.
+- Keep `docs/reviewer-path.md`, this reviewer pack, `docs/architecture.md`, and demo READMEs aligned with actual CLI behavior.
+- Regenerate and inspect committed artifacts after behavior changes.
+- Run `pytest` and confirm reviewer-doc tests still cover the demo matrix, artifact contract, and architecture boundaries.
+- Do not add SIEM, dashboard, alert routing, case-management, real-time ingestion, autonomous response, or final-verdict claims.
+
 ## Fast Verification
 
 From the repository root:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,6 +20,8 @@ Recently added:
 4. Keep the architecture diagram aligned with actual CLI and artifact behavior.
 5. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
+The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
+
 ## Optional Final Demo
 
 At most one more demo should be added before v1-style consolidation.

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -131,6 +131,21 @@ def test_reviewer_pack_freezes_stable_artifact_names() -> None:
         assert (REPO_ROOT / artifact_path).is_file(), artifact_path
 
 
+def test_reviewer_pack_defines_v1_readiness_gate() -> None:
+    reviewer_pack = _read_repo_file("docs/reviewer-pack.md")
+    roadmap = _read_repo_file("docs/roadmap.md")
+    readme = _read_repo_file("README.md")
+
+    assert "## v1 Readiness Gate" in reviewer_pack
+    assert "four-demo matrix stable" in reviewer_pack
+    assert "reviewer-visible artifact names stable" in reviewer_pack
+    assert "Regenerate and inspect committed artifacts" in reviewer_pack
+    assert "Run `pytest`" in reviewer_pack
+    assert "Do not add SIEM, dashboard, alert routing" in reviewer_pack
+    assert "[`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate)" in roadmap
+    assert "[`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate)" in readme
+
+
 def test_architecture_doc_keeps_local_file_based_boundaries() -> None:
     architecture = _read_repo_file("docs/architecture.md")
 


### PR DESCRIPTION
## Summary
- Adds a v1 readiness gate to the top-level reviewer pack
- Links the gate from README and roadmap so consolidation criteria are easy to find
- Extends reviewer-doc tests to protect the gate, artifact contract, and no-platform boundary

## Validation
- pytest tests/test_reviewer_docs.py --basetemp .pytest-artifacts-readiness-gate
- pytest --basetemp .pytest-artifacts-full-20260528-1
- git diff --cached --check