### PR TITLE
Check reviewer markdown link integrity

### DIFF
--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -11,8 +11,8 @@ MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 def _markdown_files() -> list[Path]:
     return [
         REPO_ROOT / "README.md",
-        *sorted((REPO_ROOT / "docs").glob("*.md")),
-        *sorted((REPO_ROOT / "demos").glob("*/README.md")),
+        *sorted((REPO_ROOT / "docs").rglob("*.md")),
+        *sorted((REPO_ROOT / "demos").rglob("*.md")),
     ]
 
 

--- a/tests/test_markdown_links.py
+++ b/tests/test_markdown_links.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+
+def _markdown_files() -> list[Path]:
+    return [
+        REPO_ROOT / "README.md",
+        *sorted((REPO_ROOT / "docs").glob("*.md")),
+        *sorted((REPO_ROOT / "demos").glob("*/README.md")),
+    ]
+
+
+def _local_target(raw_target: str) -> str | None:
+    target = raw_target.strip()
+    if not target or target.startswith("#"):
+        return None
+    if target.startswith(("http://", "https://", "mailto:")):
+        return None
+    if " " in target:
+        target = target.split(" ", 1)[0]
+    return target.split("#", 1)[0]
+
+
+def test_public_markdown_local_links_point_to_existing_paths() -> None:
+    missing_links: list[str] = []
+
+    for markdown_path in _markdown_files():
+        text = markdown_path.read_text(encoding="utf-8")
+        for match in MARKDOWN_LINK_RE.finditer(text):
+            target = _local_target(match.group(1))
+            if target is None:
+                continue
+
+            resolved = (markdown_path.parent / target).resolve()
+            try:
+                resolved.relative_to(REPO_ROOT.resolve())
+            except ValueError:
+                missing_links.append(
+                    f"{markdown_path.relative_to(REPO_ROOT)} links outside repo: {target}"
+                )
+                continue
+
+            if not resolved.exists():
+                missing_links.append(
+                    f"{markdown_path.relative_to(REPO_ROOT)} -> {target}"
+                )
+
+    assert missing_links == []


### PR DESCRIPTION
## Summary
- Adds a local Markdown link integrity regression test for README, docs, and demo README files
- Checks repository-relative links and image paths without requiring network access
- Protects reviewer navigation surfaces from broken local links during consolidation

## Validation
- pytest tests/test_markdown_links.py --basetemp .pytest-artifacts-markdown-links
- pytest --basetemp .pytest-artifacts-full-20260531-1
- git diff --cached --check