### PR TITLE
Align public metadata framing

### DIFF
--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -53,6 +53,7 @@ Before treating the repo as v1-style consolidated:
 - Keep the four-demo matrix stable, or document any intentional retirement in the README, reviewer path, reviewer pack, roadmap, and tests.
 - Keep reviewer-visible artifact names stable, or update the artifact naming contract and committed sample outputs in the same change.
 - Keep `docs/reviewer-path.md`, this reviewer pack, `docs/architecture.md`, and demo READMEs aligned with actual CLI behavior.
+- Keep README, package metadata, and repository metadata aligned with the local, file-based detection workflow lab framing.
 - Regenerate and inspect committed artifacts after behavior changes.
 - Run `pytest` and confirm reviewer-doc tests still cover the demo matrix, artifact contract, and architecture boundaries.
 - Do not add SIEM, dashboard, alert routing, case-management, real-time ingestion, autonomous response, or final-verdict claims.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "telemetry-window-demo"
 version = "0.1.0"
-description = "A small prototype for windowed telemetry analytics on timestamped event streams."
+description = "A local, file-based detection workflow lab for reviewer-verifiable telemetry and detection demos."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
@@ -27,4 +27,3 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 
@@ -76,6 +77,10 @@ def _read_repo_file(relative_path: str) -> str:
     return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
 
 
+def _read_pyproject() -> dict[str, object]:
+    return tomllib.loads(_read_repo_file("pyproject.toml"))
+
+
 def test_reviewer_path_keeps_detection_lab_positioning() -> None:
     reviewer_path = _read_repo_file("docs/reviewer-path.md")
     normalized = reviewer_path.lower()
@@ -105,6 +110,18 @@ def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     assert "[`docs/reviewer-pack.md`](docs/reviewer-pack.md)" in readme
     assert "[`docs/reviewer-path.md`](docs/reviewer-path.md)" in readme
     assert "[`docs/architecture.md`](docs/architecture.md)" in readme
+
+
+def test_package_metadata_uses_detection_lab_framing() -> None:
+    pyproject = _read_pyproject()
+    description = str(pyproject["project"]["description"])
+
+    assert description == (
+        "A local, file-based detection workflow lab for "
+        "reviewer-verifiable telemetry and detection demos."
+    )
+    assert "small prototype" not in description.lower()
+    assert "monitoring platform" not in description.lower()
 
 
 def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
@@ -139,6 +156,7 @@ def test_reviewer_pack_defines_v1_readiness_gate() -> None:
     assert "## v1 Readiness Gate" in reviewer_pack
     assert "four-demo matrix stable" in reviewer_pack
     assert "reviewer-visible artifact names stable" in reviewer_pack
+    assert "package metadata, and repository metadata" in reviewer_pack
     assert "Regenerate and inspect committed artifacts" in reviewer_pack
     assert "Run `pytest`" in reviewer_pack
     assert "Do not add SIEM, dashboard, alert routing" in reviewer_pack


### PR DESCRIPTION
## Summary
- Aligns package metadata with the detection workflow lab framing used by README and reviewer docs
- Adds reviewer-doc coverage so pyproject metadata does not drift back to single-demo prototype language
- Extends the v1 readiness gate to include README, package metadata, and repository metadata alignment

## Validation
- pytest tests/test_reviewer_docs.py --basetemp .pytest-artifacts-metadata-framing
- pytest --basetemp .pytest-artifacts-full-20260606-1
- git diff --cached --check