### PR TITLE
Remove stale prototype framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Latest milestone: [v0.6.0 — fourth demo and config-change investigation](https
 
 | Demo | Input | Deterministic core | LLM role | Main artifacts | Guardrails / non-goals |
 | --- | --- | --- | --- | --- | --- |
-| [telemetry-window-demo](#telemetry-window-demo) | JSONL / CSV events | Windows<br>Features<br>Alert thresholds | None | `features.csv`<br>`alerts.csv`<br>`summary.json`<br>3 PNG plots | MVP only<br>No realtime<br>No case management |
+| [telemetry-window-demo](#telemetry-window-demo) | JSONL / CSV events | Windows<br>Features<br>Alert thresholds | None | `features.csv`<br>`alerts.csv`<br>`summary.json`<br>3 PNG plots | Local demo only<br>No realtime<br>No case management |
 | [ai-assisted-detection-demo](demos/ai-assisted-detection-demo/README.md) | JSONL auth / web / process | Normalize<br>Rules<br>Grouping<br>ATT&CK mapping | JSON-only case drafting | `rule_hits.json`<br>`case_bundles.json`<br>`case_summaries.json`<br>`case_report.md`<br>`audit_traces.jsonl` | Human verification required<br>No autonomous response<br>No final verdict |
 | [rule-evaluation-and-dedup-demo](demos/rule-evaluation-and-dedup-demo/README.md) | JSON raw rule hits | Scope resolution<br>Cooldown grouping<br>Suppression reasoning | None | `rule_hits_before_dedup.json`<br>`rule_hits_after_dedup.json`<br>`dedup_explanations.json`<br>`dedup_report.md` | No realtime<br>No dashboard<br>No AI stage |
 | [config-change-investigation-demo](demos/config-change-investigation-demo/README.md) | JSONL config changes<br>Policy denials<br>Follow-on events | Normalize<br>Risky-change rules<br>Bounded correlation | None | `change_events_normalized.json`<br>`investigation_hits.json`<br>`investigation_summary.json`<br>`investigation_report.md` | No realtime<br>No dashboard<br>No AI stage |
@@ -161,7 +161,7 @@ Cooldown behavior:
 
 ## Scope
 
-This repository is a portfolio prototype, not a production monitoring system.
+This repository is a local, reviewer-oriented detection workflow lab, not a production monitoring system.
 
 ## Limitations
 

--- a/docs/reviewer-brief.md
+++ b/docs/reviewer-brief.md
@@ -67,7 +67,7 @@ The other demos emit reviewer-facing artifacts such as `dedup_report.md`, `inves
 - no alert routing, dashboarding, or case management
 - sample-data driven, not connected to live systems
 - no streaming state management
-- intentionally small-scope demos rather than a unified monitoring platform
+- intentionally small-scope detection workflow demos rather than a unified monitoring platform
 
 ## Next milestone
 

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -83,6 +83,7 @@ def _read_pyproject() -> dict[str, object]:
 
 def test_reviewer_path_keeps_detection_lab_positioning() -> None:
     reviewer_path = _read_repo_file("docs/reviewer-path.md")
+    reviewer_brief = _read_repo_file("docs/reviewer-brief.md")
     normalized = reviewer_path.lower()
 
     assert "controlled detection workflow portfolio" in reviewer_path
@@ -90,6 +91,7 @@ def test_reviewer_path_keeps_detection_lab_positioning() -> None:
     assert "not a dashboard" in normalized
     assert "not an unfinished monitoring platform" in normalized
     assert "local and file-based" in normalized
+    assert "small-scope detection workflow demos" in reviewer_brief
 
 
 def test_reviewer_path_matrix_references_committed_artifacts() -> None:
@@ -104,12 +106,16 @@ def test_reviewer_path_matrix_references_committed_artifacts() -> None:
 
 def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     readme = _read_repo_file("README.md")
+    normalized = readme.lower()
 
     assert "A local, file-based detection workflow lab" in readme
+    assert "local, reviewer-oriented detection workflow lab" in readme
     assert "not a SIEM, dashboard, or monitoring platform" in readme
     assert "[`docs/reviewer-pack.md`](docs/reviewer-pack.md)" in readme
     assert "[`docs/reviewer-path.md`](docs/reviewer-path.md)" in readme
     assert "[`docs/architecture.md`](docs/architecture.md)" in readme
+    assert "portfolio prototype" not in normalized
+    assert "mvp only" not in normalized
 
 
 def test_package_metadata_uses_detection_lab_framing() -> None:


### PR DESCRIPTION
## Summary
- replace stale README MVP/prototype wording with local reviewer-oriented detection workflow lab framing
- clarify reviewer brief limitations as small-scope detection workflow demos
- add reviewer-doc assertions to prevent stale prototype/MVP wording from returning

## Validation
- pytest tests/test_reviewer_docs.py --basetemp .pytest-artifacts-stale-framing
- pytest --basetemp .pytest-artifacts-full-stale-framing
- git diff --check
- git diff privacy/secret keyword scan