### PR TITLE
Link reviewer brief from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Cooldown behavior:
 - [`demos/rule-evaluation-and-dedup-demo/README.md`](demos/rule-evaluation-and-dedup-demo/README.md) explains the third demo and links its committed before/after dedup artifacts
 - [`demos/config-change-investigation-demo/README.md`](demos/config-change-investigation-demo/README.md) explains the config-change investigation demo and its committed artifacts
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
+- [`docs/reviewer-brief.md`](docs/reviewer-brief.md) gives the short problem, value, evidence, and boundary summary
 - [`docs/reviewer-path.md`](docs/reviewer-path.md) maps common review questions to the right demo and artifacts
 - [`docs/architecture.md`](docs/architecture.md) diagrams the local file-based detection workflow
 - [`docs/sample-output.md`](docs/sample-output.md) summarizes the committed sample artifacts

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -112,6 +112,7 @@ def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     assert "local, reviewer-oriented detection workflow lab" in readme
     assert "not a SIEM, dashboard, or monitoring platform" in readme
     assert "[`docs/reviewer-pack.md`](docs/reviewer-pack.md)" in readme
+    assert "[`docs/reviewer-brief.md`](docs/reviewer-brief.md)" in readme
     assert "[`docs/reviewer-path.md`](docs/reviewer-path.md)" in readme
     assert "[`docs/architecture.md`](docs/architecture.md)" in readme
     assert "portfolio prototype" not in normalized


### PR DESCRIPTION
## Summary
- add docs/reviewer-brief.md to the README Repo Guide
- assert the README keeps the reviewer brief entrypoint alongside the reviewer pack/path/architecture links

## Validation
- pytest tests/test_reviewer_docs.py tests/test_markdown_links.py --basetemp .pytest-artifacts-reviewer-brief-link
- pytest --basetemp .pytest-artifacts-full-reviewer-brief-link
- git diff --check
- git diff privacy/secret keyword scan