### PR TITLE
Add reviewer start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ A local, file-based detection workflow lab for reviewer-verifiable telemetry and
 
 Latest milestone: [v0.6.0 — fourth demo and config-change investigation](https://github.com/stacknil/telemetry-lab/releases/latest).
 
+## Reviewer Start
+
+- [`docs/reviewer-brief.md`](docs/reviewer-brief.md): scope, value, evidence, and boundaries
+- [`docs/reviewer-path.md`](docs/reviewer-path.md): choose the right demo by review question
+- [`docs/reviewer-pack.md`](docs/reviewer-pack.md): demo matrix, artifact contract, and v1 readiness gate
+- [`docs/README.md`](docs/README.md): current route, supporting docs, and historical release evidence
+
 ## Demos
 
 - [telemetry-window-demo](#telemetry-window-demo)

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -111,6 +111,11 @@ def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     assert "A local, file-based detection workflow lab" in readme
     assert "local, reviewer-oriented detection workflow lab" in readme
     assert "not a SIEM, dashboard, or monitoring platform" in readme
+    assert "## Reviewer Start" in readme
+    assert "scope, value, evidence, and boundaries" in readme
+    assert "choose the right demo by review question" in readme
+    assert "demo matrix, artifact contract, and v1 readiness gate" in readme
+    assert "current route, supporting docs, and historical release evidence" in readme
     assert "[`docs/README.md`](docs/README.md)" in readme
     assert "[`docs/reviewer-pack.md`](docs/reviewer-pack.md)" in readme
     assert "[`docs/reviewer-brief.md`](docs/reviewer-brief.md)" in readme


### PR DESCRIPTION
## Summary
- add a top-level Reviewer Start section to the README
- front-load links to the reviewer brief, reviewer path, reviewer pack, and docs index
- add reviewer-doc assertions so the start section remains stable

## Validation
- pytest tests/test_reviewer_docs.py tests/test_markdown_links.py --basetemp .pytest-artifacts-reviewer-start
- pytest --basetemp .pytest-artifacts-full-reviewer-start
- git diff --check
- diff privacy/secret keyword scan