### PR TITLE
Align reviewer pack anchors

### DIFF
--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -75,10 +75,12 @@ Use the same Python interpreter for install, tests, and demo commands.
 
 ## Review Anchors
 
+- [`docs/README.md`](README.md): docs index for the current route, supporting docs, and historical release evidence
 - [`docs/reviewer-brief.md`](reviewer-brief.md): short problem / value summary
 - [`docs/reviewer-path.md`](reviewer-path.md): demo choice by review question
 - [`docs/architecture.md`](architecture.md): local file-based workflow diagram
 - [`docs/sample-output.md`](sample-output.md): committed output counts and sample artifacts
+- [`docs/roadmap.md`](roadmap.md): v0.7 / v1.0 consolidation direction
 - [`tests/test_reviewer_docs.py`](../tests/test_reviewer_docs.py): regression checks for reviewer-facing docs
 
 ## Boundaries

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -169,8 +169,11 @@ def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
 
     assert "top-level reviewer pack" in reviewer_pack
     assert "Artifact Naming Contract" in reviewer_pack
+    assert "[`docs/README.md`](README.md)" in reviewer_pack
     assert "[`docs/reviewer-path.md`](reviewer-path.md)" in reviewer_pack
     assert "[`docs/architecture.md`](architecture.md)" in reviewer_pack
+    assert "[`docs/roadmap.md`](roadmap.md)" in reviewer_pack
+    assert "current route, supporting docs, and historical release evidence" in reviewer_pack
 
     for question, demo_name, artifact_paths in REVIEWER_DEMO_MATRIX:
         assert question in reviewer_pack


### PR DESCRIPTION
## Summary
- add docs/README.md to the reviewer pack Review Anchors
- add docs/roadmap.md to the same anchor list
- lock the reviewer pack anchor alignment in reviewer-doc tests

## Validation
- pytest tests/test_reviewer_docs.py tests/test_markdown_links.py --basetemp .pytest-artifacts-pack-anchors
- pytest --basetemp .pytest-artifacts-full-pack-anchors
- git diff --check
- diff privacy/secret keyword scan