### PR TITLE
feat(contract): add evidence pipeline schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Latest tagged release: [v0.6.0 — fourth demo and config-change investigation](
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md): scope, value, evidence, and boundaries
 - [`docs/reviewer-path.md`](docs/reviewer-path.md): choose the right demo by review question
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md): demo matrix, artifact contract, and v1 readiness gate
+- [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`docs/README.md`](docs/README.md): current route, supporting docs, and historical release evidence
 
 ## Demos
@@ -163,6 +164,7 @@ Cooldown behavior:
 - [`demos/cloud-iam-change-investigation-demo/README.md`](demos/cloud-iam-change-investigation-demo/README.md) explains the synthetic CloudTrail-like IAM investigation demo and its committed artifacts
 - [`docs/README.md`](docs/README.md) indexes current reviewer docs, supporting design notes, and historical release evidence
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
+- [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md) maps v1 evidence schemas to committed JSON artifacts
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md) gives the short problem, value, evidence, and boundary summary
 - [`docs/reviewer-path.md`](docs/reviewer-path.md) maps common review questions to the right demo and artifacts
 - [`docs/architecture.md`](docs/architecture.md) diagrams the local file-based detection workflow
@@ -178,6 +180,7 @@ Cooldown behavior:
 - demo expansion is closed
 - stabilize the five-demo matrix and avoid broad platform expansion
 - freeze reviewer-visible artifact names unless a rename is intentionally coordinated across docs, tests, and sample outputs
+- keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts
 - use [`docs/reviewer-pack.md`](docs/reviewer-pack.md) and [`docs/architecture.md`](docs/architecture.md) as the consolidation entrypoints
 - use the [`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate) before treating the repo as consolidated
 - avoid additional demo expansion during v1 reviewer contract stabilization

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory separates the current reviewer route from supporting design notes
 - [`reviewer-pack.md`](reviewer-pack.md): top-level reviewer pack, demo matrix, artifact naming contract, and v1 readiness gate
 - [`reviewer-path.md`](reviewer-path.md): choose a demo by review question
 - [`reviewer-brief.md`](reviewer-brief.md): short problem, value, evidence, and boundary summary
+- [`evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`architecture.md`](architecture.md): local file-based workflow diagram
 - [`roadmap.md`](roadmap.md): v1 reviewer contract stabilization phase
 

--- a/docs/evidence-pipeline-contract.md
+++ b/docs/evidence-pipeline-contract.md
@@ -1,0 +1,39 @@
+# Evidence Pipeline Contract
+
+`telemetry-lab` v1.0 treats reviewer-facing JSON artifacts as evidence pipeline contracts. The schemas below define the current machine-readable artifact shapes for selected demo outputs without turning the repo into a SIEM, dashboard, or monitoring platform.
+
+The contract is intentionally local and file-based:
+
+- schemas live under `schemas/`
+- committed artifacts live under `demos/*/artifacts/`
+- tests validate the schemas against the committed artifacts
+- raw evidence payloads may preserve source-specific fields, but deterministic wrapper fields stay explicit
+
+## Schema Matrix
+
+| Schema | Demo artifact | What it locks |
+| --- | --- | --- |
+| `schemas/rule_hits.schema.json` | `demos/ai-assisted-detection-demo/artifacts/rule_hits.json` | deterministic rule-hit fields before case grouping |
+| `schemas/case_bundles.schema.json` | `demos/ai-assisted-detection-demo/artifacts/case_bundles.json` | bounded case bundles passed to JSON-only drafting |
+| `schemas/dedup_explanations.schema.json` | `demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json` | retained/suppressed cooldown explanations |
+| `schemas/investigation_signals.schema.json` | `demos/cloud-iam-change-investigation-demo/artifacts/investigation_signals.json` | bounded CloudTrail-like investigation signals |
+| `schemas/investigation_summary.schema.json` | `demos/cloud-iam-change-investigation-demo/artifacts/investigation_summary.json` | Cloud IAM investigation summary and time-model metadata |
+
+## Contract Rules
+
+- Schema files use JSON Schema Draft 2020-12.
+- Contracted wrapper fields reject unknown properties unless the field intentionally preserves raw source evidence.
+- Timestamps use RFC 3339 / JSON Schema `date-time` strings.
+- Severity values are limited to `low`, `medium`, `high`, and `critical`.
+- The Cloud IAM schemas preserve the event-time model: `eventTime` is normalized to `event_time`, optional `observedTime` is preserved as `observed_time`, and detection ordering is documented as `event_time`.
+- These schemas describe reviewer evidence only. They do not claim production alert routing, case management, autonomous response, or final incident verdicts.
+
+## Verification
+
+Run:
+
+```bash
+python -m pytest tests/test_evidence_pipeline_schemas.py
+```
+
+The test validates each schema file and checks that the committed artifact listed in the schema matrix conforms to it.

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -37,6 +37,18 @@ The current artifact names are reviewer-facing contracts for the v1 reviewer con
 - If an artifact must be renamed, update the README, reviewer path, this reviewer pack, demo README, tests, and committed sample outputs in the same change.
 - Do not introduce platform-style names that imply alert routing, case management, real-time ingestion, or autonomous response.
 
+## Evidence Pipeline Contract
+
+See [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md) for the v1 JSON schema contract covering selected reviewer-facing evidence artifacts.
+
+The current schema contract covers:
+
+- `schemas/rule_hits.schema.json`
+- `schemas/case_bundles.schema.json`
+- `schemas/dedup_explanations.schema.json`
+- `schemas/investigation_signals.schema.json`
+- `schemas/investigation_summary.schema.json`
+
 ### Stable Reviewer-Visible Artifacts
 
 | Area | Stable artifact paths |
@@ -81,6 +93,7 @@ Use the same Python interpreter for install, tests, and demo commands.
 - [`docs/README.md`](README.md): docs index for the current route, supporting docs, and historical release evidence
 - [`docs/reviewer-brief.md`](reviewer-brief.md): short problem / value summary
 - [`docs/reviewer-path.md`](reviewer-path.md): demo choice by review question
+- [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for selected evidence artifacts
 - [`docs/architecture.md`](architecture.md): local file-based workflow diagram
 - [`docs/sample-output.md`](sample-output.md): committed output counts and sample artifacts
 - [`docs/roadmap.md`](roadmap.md): v1 reviewer contract stabilization phase

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,9 +19,10 @@ Recently added:
 
 1. Stabilize the demo matrix.
 2. Freeze reviewer-visible artifact names unless a rename is intentional and documented across README, reviewer docs, demo docs, tests, and sample outputs.
-3. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
-4. Keep the architecture diagram aligned with actual CLI and artifact behavior.
-5. Prefer regression tests and documentation accuracy over adding new workflow surface area.
+3. Keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts.
+4. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
+5. Keep the architecture diagram aligned with actual CLI and artifact behavior.
+6. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
 The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = [
+  "jsonschema>=4.0",
+  "pytest>=8.0",
+]
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/schemas/case_bundles.schema.json
+++ b/schemas/case_bundles.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stacknil/telemetry-lab/schemas/case_bundles.schema.json",
+  "title": "AI-assisted detection case bundles",
+  "description": "Schema for demos/ai-assisted-detection-demo/artifacts/case_bundles.json.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "case_id",
+      "telemetry_classification",
+      "first_seen",
+      "last_seen",
+      "severity",
+      "entities",
+      "rule_hits",
+      "attack_mappings",
+      "evidence_highlights",
+      "raw_evidence"
+    ],
+    "properties": {
+      "case_id": { "type": "string", "pattern": "^CASE-[0-9]{3}$" },
+      "telemetry_classification": { "type": "string", "const": "untrusted_data" },
+      "first_seen": { "type": "string", "format": "date-time" },
+      "last_seen": { "type": "string", "format": "date-time" },
+      "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "entities": {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "rule_hits": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/rule_hit" }
+      },
+      "attack_mappings": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/attack_mapping" }
+      },
+      "evidence_highlights": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "raw_evidence": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/raw_evidence" }
+      }
+    }
+  },
+  "$defs": {
+    "attack_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tactic", "technique_id", "technique_name"],
+      "properties": {
+        "tactic": { "type": "string", "minLength": 1 },
+        "technique_id": { "type": "string", "pattern": "^T[0-9]{4}(\\.[0-9]{3})?$" },
+        "technique_name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "rule_hit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hit_id",
+        "rule_id",
+        "rule_name",
+        "severity",
+        "event_family",
+        "detected_at",
+        "event_ids",
+        "entity_keys",
+        "summary",
+        "evidence_highlights",
+        "attack_mapping"
+      ],
+      "properties": {
+        "hit_id": { "type": "string", "minLength": 1 },
+        "rule_id": { "type": "string", "minLength": 1 },
+        "rule_name": { "type": "string", "minLength": 1 },
+        "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+        "event_family": { "type": "string", "minLength": 1 },
+        "detected_at": { "type": "string", "format": "date-time" },
+        "event_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "entity_keys": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "summary": { "type": "string", "minLength": 1 },
+        "evidence_highlights": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "attack_mapping": { "$ref": "#/$defs/attack_mapping" }
+      }
+    },
+    "raw_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "timestamp",
+        "event_family",
+        "principal",
+        "src_ip",
+        "host",
+        "target",
+        "action",
+        "outcome",
+        "url_path",
+        "command_line",
+        "raw_message",
+        "raw_event",
+        "entity_keys"
+      ],
+      "properties": {
+        "event_id": { "type": "string", "minLength": 1 },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "event_family": { "type": "string", "minLength": 1 },
+        "principal": { "type": "string" },
+        "src_ip": { "type": "string" },
+        "host": { "type": "string" },
+        "target": { "type": "string" },
+        "action": { "type": "string" },
+        "outcome": { "type": "string" },
+        "url_path": { "type": "string" },
+        "command_line": { "type": "string" },
+        "raw_message": { "type": "string" },
+        "raw_event": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "entity_keys": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/schemas/dedup_explanations.schema.json
+++ b/schemas/dedup_explanations.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stacknil/telemetry-lab/schemas/dedup_explanations.schema.json",
+  "title": "Rule evaluation dedup explanations",
+  "description": "Schema for demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "hit_id",
+      "rule_name",
+      "severity",
+      "alert_time",
+      "cooldown_scope",
+      "scope_source",
+      "cooldown_key",
+      "status",
+      "reason",
+      "group_position",
+      "group_size",
+      "cooldown_seconds",
+      "suppressed_by_hit_id",
+      "seconds_since_last_retained",
+      "message"
+    ],
+    "properties": {
+      "hit_id": { "type": "string", "minLength": 1 },
+      "rule_name": { "type": "string", "minLength": 1 },
+      "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "alert_time": { "type": "string", "format": "date-time" },
+      "cooldown_scope": {
+        "type": ["string", "null"],
+        "minLength": 1
+      },
+      "scope_source": { "type": "string", "minLength": 1 },
+      "cooldown_key": { "type": "string", "minLength": 1 },
+      "status": { "type": "string", "enum": ["retained", "suppressed"] },
+      "reason": { "type": "string", "minLength": 1 },
+      "group_position": { "type": "integer", "minimum": 1 },
+      "group_size": { "type": "integer", "minimum": 1 },
+      "cooldown_seconds": { "type": "integer", "minimum": 0 },
+      "suppressed_by_hit_id": {
+        "type": ["string", "null"],
+        "minLength": 1
+      },
+      "seconds_since_last_retained": {
+        "type": ["integer", "null"],
+        "minimum": 0
+      },
+      "message": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/schemas/investigation_signals.schema.json
+++ b/schemas/investigation_signals.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stacknil/telemetry-lab/schemas/investigation_signals.schema.json",
+  "title": "Cloud IAM investigation signals",
+  "description": "Schema for demos/cloud-iam-change-investigation-demo/artifacts/investigation_signals.json.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "signal_id",
+      "rule_id",
+      "rule_name",
+      "severity",
+      "signal_time",
+      "actor",
+      "primary_event_id",
+      "source_ips",
+      "evidence_event_ids",
+      "evidence_events",
+      "attack_mappings",
+      "bounded_correlation_reason",
+      "review_scope"
+    ],
+    "properties": {
+      "signal_id": { "type": "string", "pattern": "^CTI-[0-9]{3}$" },
+      "rule_id": { "type": "string", "minLength": 1 },
+      "rule_name": { "type": "string", "minLength": 1 },
+      "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "signal_time": { "type": "string", "format": "date-time" },
+      "actor": { "type": "string", "minLength": 1 },
+      "primary_event_id": { "type": "string", "minLength": 1 },
+      "source_ips": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "evidence_event_ids": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "evidence_events": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/evidence_event" }
+      },
+      "attack_mappings": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/$defs/attack_mapping" }
+      },
+      "bounded_correlation_reason": { "type": "string", "minLength": 1 },
+      "review_scope": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "attack_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "tactic", "reference"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^T[0-9]{4}(\\.[0-9]{3})?$" },
+        "name": { "type": "string", "minLength": 1 },
+        "tactic": { "type": "string", "minLength": 1 },
+        "reference": { "type": "string", "format": "uri" }
+      }
+    },
+    "evidence_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventID",
+        "event_time",
+        "observed_time",
+        "eventTime",
+        "actor",
+        "eventSource",
+        "eventName",
+        "awsRegion",
+        "sourceIPAddress",
+        "errorCode",
+        "requestParameters"
+      ],
+      "properties": {
+        "eventID": { "type": "string", "minLength": 1 },
+        "event_time": { "type": "string", "format": "date-time" },
+        "observed_time": { "type": ["string", "null"], "format": "date-time" },
+        "eventTime": { "type": "string", "format": "date-time" },
+        "actor": { "type": "string", "minLength": 1 },
+        "eventSource": { "type": "string", "minLength": 1 },
+        "eventName": { "type": "string", "minLength": 1 },
+        "awsRegion": { "type": "string", "minLength": 1 },
+        "sourceIPAddress": { "type": "string", "minLength": 1 },
+        "errorCode": { "type": ["string", "null"] },
+        "requestParameters": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/schemas/investigation_summary.schema.json
+++ b/schemas/investigation_summary.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stacknil/telemetry-lab/schemas/investigation_summary.schema.json",
+  "title": "Cloud IAM investigation summary",
+  "description": "Schema for demos/cloud-iam-change-investigation-demo/artifacts/investigation_summary.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source_type",
+    "event_count",
+    "signal_count",
+    "rule_counts",
+    "attack_mapping_count",
+    "time_model",
+    "boundaries"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "cloud-iam-change-investigation-demo/v1"
+    },
+    "source_type": { "type": "string", "minLength": 1 },
+    "event_count": { "type": "integer", "minimum": 0 },
+    "signal_count": { "type": "integer", "minimum": 0 },
+    "rule_counts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "attack_mapping_count": { "type": "integer", "minimum": 0 },
+    "time_model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_time_source",
+        "observed_time_source",
+        "detection_ordering",
+        "observed_time_event_count"
+      ],
+      "properties": {
+        "event_time_source": { "type": "string", "const": "eventTime" },
+        "observed_time_source": { "type": "string", "const": "observedTime when present" },
+        "detection_ordering": { "type": "string", "const": "event_time" },
+        "observed_time_event_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/schemas/rule_hits.schema.json
+++ b/schemas/rule_hits.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/stacknil/telemetry-lab/schemas/rule_hits.schema.json",
+  "title": "AI-assisted detection rule hits",
+  "description": "Schema for demos/ai-assisted-detection-demo/artifacts/rule_hits.json.",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "hit_id",
+      "rule_id",
+      "rule_name",
+      "severity",
+      "event_family",
+      "detected_at",
+      "event_ids",
+      "entity_keys",
+      "summary",
+      "evidence_highlights",
+      "attack_mapping"
+    ],
+    "properties": {
+      "hit_id": { "type": "string", "minLength": 1 },
+      "rule_id": { "type": "string", "minLength": 1 },
+      "rule_name": { "type": "string", "minLength": 1 },
+      "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+      "event_family": { "type": "string", "minLength": 1 },
+      "detected_at": { "type": "string", "format": "date-time" },
+      "event_ids": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "entity_keys": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "summary": { "type": "string", "minLength": 1 },
+      "evidence_highlights": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "type": "string", "minLength": 1 }
+      },
+      "attack_mapping": { "$ref": "#/$defs/attack_mapping" }
+    }
+  },
+  "$defs": {
+    "attack_mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tactic", "technique_id", "technique_name"],
+      "properties": {
+        "tactic": { "type": "string", "minLength": 1 },
+        "technique_id": { "type": "string", "pattern": "^T[0-9]{4}(\\.[0-9]{3})?$" },
+        "technique_name": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/tests/test_evidence_pipeline_schemas.py
+++ b/tests/test_evidence_pipeline_schemas.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA_CONTRACTS = {
+    "schemas/rule_hits.schema.json": [
+        "demos/ai-assisted-detection-demo/artifacts/rule_hits.json",
+    ],
+    "schemas/case_bundles.schema.json": [
+        "demos/ai-assisted-detection-demo/artifacts/case_bundles.json",
+    ],
+    "schemas/dedup_explanations.schema.json": [
+        "demos/rule-evaluation-and-dedup-demo/artifacts/dedup_explanations.json",
+    ],
+    "schemas/investigation_signals.schema.json": [
+        "demos/cloud-iam-change-investigation-demo/artifacts/investigation_signals.json",
+    ],
+    "schemas/investigation_summary.schema.json": [
+        "demos/cloud-iam-change-investigation-demo/artifacts/investigation_summary.json",
+    ],
+}
+
+
+def _load_json(relative_path: str) -> object:
+    return json.loads((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def _error_summary(errors: list[object]) -> str:
+    lines: list[str] = []
+    for error in errors[:5]:
+        path = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        lines.append(f"{path}: {error.message}")
+    return "\n".join(lines)
+
+
+def test_evidence_pipeline_schemas_validate_committed_artifacts() -> None:
+    for schema_path, artifact_paths in SCHEMA_CONTRACTS.items():
+        schema = _load_json(schema_path)
+        Draft202012Validator.check_schema(schema)
+        validator = Draft202012Validator(schema, format_checker=FormatChecker())
+
+        for artifact_path in artifact_paths:
+            errors = sorted(
+                validator.iter_errors(_load_json(artifact_path)),
+                key=lambda error: list(error.absolute_path),
+            )
+            assert errors == [], f"{schema_path} failed for {artifact_path}\n{_error_summary(errors)}"
+
+
+def test_evidence_pipeline_contract_docs_reference_schemas_and_artifacts() -> None:
+    contract_doc = (REPO_ROOT / "docs" / "evidence-pipeline-contract.md").read_text(
+        encoding="utf-8"
+    )
+    reviewer_pack = (REPO_ROOT / "docs" / "reviewer-pack.md").read_text(
+        encoding="utf-8"
+    )
+    docs_index = (REPO_ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "Evidence Pipeline Contract" in contract_doc
+    assert "evidence-pipeline-contract.md" in reviewer_pack
+    assert "evidence-pipeline-contract.md" in docs_index
+    assert "docs/evidence-pipeline-contract.md" in readme
+
+    for schema_path, artifact_paths in SCHEMA_CONTRACTS.items():
+        assert f"`{schema_path}`" in contract_doc
+        assert (REPO_ROOT / schema_path).is_file(), schema_path
+        for artifact_path in artifact_paths:
+            assert f"`{artifact_path}`" in contract_doc
+            assert (REPO_ROOT / artifact_path).is_file(), artifact_path


### PR DESCRIPTION
## Summary
- add JSON Schema Draft 2020-12 contracts for TL-01 schema-contract outputs
- map rule_hits, case_bundles, dedup_explanations, investigation_signals, and investigation_summary schemas to committed demo artifacts
- add schema validation tests and link the evidence pipeline contract from README/reviewer docs

## Validation
- python -m pytest tests/test_evidence_pipeline_schemas.py
- python -m pytest tests/test_evidence_pipeline_schemas.py tests/test_reviewer_docs.py tests/test_markdown_links.py
- python -m pytest --basetemp pytest-tmp-contract
- git diff --cached --check

## Notes
- Full pytest required an elevated run because the managed sandbox denied access to pytest temporary directories.
- Schemas describe reviewer evidence artifacts only; no SIEM, dashboard, alert routing, autonomous response, or final verdict claims added.