### PR TITLE
feat(contract): add artifact regeneration check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .pytest-artifacts*/
+.artifact-regeneration-tmp/
 .coverage
 .venv/
 venv/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Other demo entrypoints:
 - `python -m telemetry_window_demo.cli run-rule-dedup-demo`
 - `python -m telemetry_window_demo.cli run-config-change-demo`
 - `python -m telemetry_window_demo.cli run-cloud-iam-change-demo`
+- `python scripts/regenerate_artifacts.py --check`
 
 Useful inspection commands:
 
@@ -181,6 +182,7 @@ Cooldown behavior:
 - stabilize the five-demo matrix and avoid broad platform expansion
 - freeze reviewer-visible artifact names unless a rename is intentionally coordinated across docs, tests, and sample outputs
 - keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts
+- keep committed artifacts aligned with regenerated pipeline output through `python scripts/regenerate_artifacts.py --check`
 - use [`docs/reviewer-pack.md`](docs/reviewer-pack.md) and [`docs/architecture.md`](docs/architecture.md) as the consolidation entrypoints
 - use the [`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate) before treating the repo as consolidated
 - avoid additional demo expansion during v1 reviewer contract stabilization

--- a/docs/evidence-pipeline-contract.md
+++ b/docs/evidence-pipeline-contract.md
@@ -33,7 +33,10 @@ The contract is intentionally local and file-based:
 Run:
 
 ```bash
+python scripts/regenerate_artifacts.py --check
 python -m pytest tests/test_evidence_pipeline_schemas.py
 ```
 
-The test validates each schema file and checks that the committed artifact listed in the schema matrix conforms to it.
+The regeneration check compares byte-stable CSV, JSON, JSONL, and Markdown artifacts with fresh pipeline output. It also regenerates PNG visual snapshots to verify that the plotting path still runs, but it does not byte-compare those images because Matplotlib rendering can vary across platforms.
+
+The schema test validates each schema file and checks that the committed artifact listed in the schema matrix conforms to it.

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -68,6 +68,7 @@ Before treating the repo as v1-style consolidated:
 - Keep reviewer-visible artifact names stable, or update the artifact naming contract and committed sample outputs in the same change.
 - Keep `docs/reviewer-path.md`, this reviewer pack, `docs/architecture.md`, and demo READMEs aligned with actual CLI behavior.
 - Keep README, package metadata, and repository metadata aligned with the local, file-based detection workflow lab framing.
+- Run `python scripts/regenerate_artifacts.py --check` to verify committed evidence artifacts match fresh pipeline output.
 - Regenerate and inspect committed artifacts after behavior changes.
 - Run `pytest` and confirm reviewer-doc tests still cover the demo matrix, artifact contract, and architecture boundaries.
 - Do not add SIEM, dashboard, alert routing, case-management, real-time ingestion, autonomous response, or final-verdict claims.
@@ -83,6 +84,7 @@ python -m telemetry_window_demo.cli run-ai-demo
 python -m telemetry_window_demo.cli run-rule-dedup-demo
 python -m telemetry_window_demo.cli run-config-change-demo
 python -m telemetry_window_demo.cli run-cloud-iam-change-demo
+python scripts/regenerate_artifacts.py --check
 pytest
 ```
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,9 +20,10 @@ Recently added:
 1. Stabilize the demo matrix.
 2. Freeze reviewer-visible artifact names unless a rename is intentional and documented across README, reviewer docs, demo docs, tests, and sample outputs.
 3. Keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts.
-4. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
-5. Keep the architecture diagram aligned with actual CLI and artifact behavior.
-6. Prefer regression tests and documentation accuracy over adding new workflow surface area.
+4. Keep committed evidence artifacts aligned with regenerated pipeline output.
+5. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
+6. Keep the architecture diagram aligned with actual CLI and artifact behavior.
+7. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
 The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
 

--- a/scripts/regenerate_artifacts.py
+++ b/scripts/regenerate_artifacts.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import shutil
+import sys
+from uuid import uuid4
+from collections.abc import Callable, Iterable, Sequence
+from contextlib import contextmanager, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+
+@dataclass(frozen=True)
+class ArtifactSet:
+    name: str
+    committed_root: Path
+    generated_root: Path
+    strict_paths: tuple[Path, ...]
+    visual_snapshot_paths: tuple[Path, ...] = ()
+
+    @property
+    def all_paths(self) -> tuple[Path, ...]:
+        return (*self.strict_paths, *self.visual_snapshot_paths)
+
+
+@dataclass(frozen=True)
+class RegenerationJob:
+    name: str
+    run: Callable[[Path], ArtifactSet]
+
+
+@dataclass(frozen=True)
+class ArtifactDifference:
+    job_name: str
+    relative_path: Path
+    committed_path: Path
+    generated_path: Path
+    reason: str
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    work_root = _resolve_repo_path(args.work_dir)
+    jobs = build_jobs()
+
+    try:
+        differences = run_regeneration_check(
+            jobs,
+            work_root=work_root,
+            check=bool(args.check),
+        )
+    finally:
+        if args.clean:
+            _clean_work_root(work_root)
+
+    if differences:
+        print(f"[FAIL] {len(differences)} artifact mismatch(es) found.")
+        for difference in differences:
+            print(
+                f"- {difference.job_name}: {difference.relative_path.as_posix()} "
+                f"({difference.reason})"
+            )
+            print(f"  committed: {_display_path(difference.committed_path)}")
+            print(f"  generated: {_display_path(difference.generated_path)}")
+        print("Run `python scripts/regenerate_artifacts.py` to update committed artifacts.")
+        return 1
+
+    return 0
+
+
+def run_regeneration_check(
+    jobs: Sequence[RegenerationJob],
+    *,
+    work_root: Path,
+    check: bool,
+) -> list[ArtifactDifference]:
+    _prepare_work_root(work_root)
+    run_root = work_root / f"run-{uuid4().hex}"
+    run_root.mkdir(parents=True)
+    differences: list[ArtifactDifference] = []
+    checked_count = 0
+    visual_count = 0
+
+    for job in jobs:
+        job_root = run_root / _slug(job.name)
+        job_root.mkdir(parents=True)
+
+        artifact_set = job.run(job_root)
+        checked_count += len(artifact_set.strict_paths)
+        visual_count += len(artifact_set.visual_snapshot_paths)
+        if check:
+            differences.extend(compare_artifact_set(job.name, artifact_set))
+        else:
+            copy_generated_artifacts(artifact_set)
+        print(f"[OK] {job.name}: {len(artifact_set.all_paths)} artifact(s) generated")
+
+    if not differences and check:
+        print(f"[OK] {checked_count} committed artifact(s) match regenerated output")
+        if visual_count:
+            print(
+                f"[OK] {visual_count} visual snapshot artifact(s) regenerated "
+                "without byte comparison"
+            )
+    elif not differences:
+        print(
+            f"[OK] {checked_count + visual_count} committed artifact(s) updated "
+            "from regenerated output"
+        )
+
+    return differences
+
+
+def compare_artifact_set(
+    job_name: str,
+    artifact_set: ArtifactSet,
+) -> list[ArtifactDifference]:
+    differences: list[ArtifactDifference] = []
+    for relative_path in artifact_set.strict_paths:
+        committed_path = artifact_set.committed_root / relative_path
+        generated_path = artifact_set.generated_root / relative_path
+
+        reason: str | None = None
+        if not committed_path.is_file():
+            reason = "committed artifact is missing"
+        elif not generated_path.is_file():
+            reason = "regenerated artifact is missing"
+        elif not artifacts_match(committed_path, generated_path):
+            reason = "content differs"
+
+        if reason is not None:
+            differences.append(
+                ArtifactDifference(
+                    job_name=job_name,
+                    relative_path=relative_path,
+                    committed_path=committed_path,
+                    generated_path=generated_path,
+                    reason=reason,
+                )
+            )
+
+    for relative_path in artifact_set.visual_snapshot_paths:
+        committed_path = artifact_set.committed_root / relative_path
+        generated_path = artifact_set.generated_root / relative_path
+
+        reason: str | None = None
+        if not committed_path.is_file():
+            reason = "committed visual artifact is missing"
+        elif not generated_path.is_file():
+            reason = "regenerated visual artifact is missing"
+
+        if reason is not None:
+            differences.append(
+                ArtifactDifference(
+                    job_name=job_name,
+                    relative_path=relative_path,
+                    committed_path=committed_path,
+                    generated_path=generated_path,
+                    reason=reason,
+                )
+            )
+    return differences
+
+
+def artifacts_match(committed_path: Path, generated_path: Path) -> bool:
+    if committed_path.suffix.lower() in {".csv", ".json", ".jsonl", ".md", ".txt"}:
+        return _normalized_text(committed_path) == _normalized_text(generated_path)
+    return committed_path.read_bytes() == generated_path.read_bytes()
+
+
+def copy_generated_artifacts(artifact_set: ArtifactSet) -> None:
+    for relative_path in artifact_set.all_paths:
+        committed_path = artifact_set.committed_root / relative_path
+        generated_path = artifact_set.generated_root / relative_path
+        committed_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(generated_path, committed_path)
+
+
+def build_jobs() -> list[RegenerationJob]:
+    return [
+        RegenerationJob(
+            name="telemetry-window-demo default sample",
+            run=lambda job_root: _run_window_pipeline_job(
+                job_root,
+                config_path=REPO_ROOT / "configs" / "default.yaml",
+                committed_root=REPO_ROOT / "data" / "processed",
+            ),
+        ),
+        RegenerationJob(
+            name="telemetry-window-demo richer sample",
+            run=lambda job_root: _run_window_pipeline_job(
+                job_root,
+                config_path=REPO_ROOT / "configs" / "richer_sample.yaml",
+                committed_root=REPO_ROOT / "data" / "processed" / "richer_sample",
+            ),
+        ),
+        RegenerationJob(
+            name="ai-assisted-detection-demo",
+            run=lambda job_root: _run_demo_job(
+                job_root,
+                committed_root=REPO_ROOT / "demos" / "ai-assisted-detection-demo" / "artifacts",
+                runner=_run_ai_demo,
+                relative_paths=(
+                    "rule_hits.json",
+                    "case_bundles.json",
+                    "case_summaries.json",
+                    "case_report.md",
+                    "audit_traces.jsonl",
+                ),
+            ),
+        ),
+        RegenerationJob(
+            name="rule-evaluation-and-dedup-demo",
+            run=lambda job_root: _run_demo_job(
+                job_root,
+                committed_root=REPO_ROOT / "demos" / "rule-evaluation-and-dedup-demo" / "artifacts",
+                runner=_run_rule_dedup_demo,
+                relative_paths=(
+                    "rule_hits_before_dedup.json",
+                    "rule_hits_after_dedup.json",
+                    "dedup_explanations.json",
+                    "dedup_report.md",
+                ),
+            ),
+        ),
+        RegenerationJob(
+            name="config-change-investigation-demo",
+            run=lambda job_root: _run_demo_job(
+                job_root,
+                committed_root=REPO_ROOT / "demos" / "config-change-investigation-demo" / "artifacts",
+                runner=_run_config_change_demo,
+                relative_paths=(
+                    "change_events_normalized.json",
+                    "investigation_hits.json",
+                    "investigation_summary.json",
+                    "investigation_report.md",
+                ),
+            ),
+        ),
+        RegenerationJob(
+            name="cloud-iam-change-investigation-demo",
+            run=lambda job_root: _run_demo_job(
+                job_root,
+                committed_root=REPO_ROOT / "demos" / "cloud-iam-change-investigation-demo" / "artifacts",
+                runner=_run_cloud_iam_demo,
+                relative_paths=(
+                    "normalized_cloudtrail_events.json",
+                    "investigation_signals.json",
+                    "investigation_summary.json",
+                    "investigation_report.md",
+                ),
+            ),
+        ),
+    ]
+
+
+def _run_window_pipeline_job(
+    job_root: Path,
+    *,
+    config_path: Path,
+    committed_root: Path,
+) -> ArtifactSet:
+    from telemetry_window_demo.cli import run_command
+    from telemetry_window_demo.io import load_config
+
+    config = load_config(config_path)
+    generated_repo = job_root / "repo"
+    generated_config_dir = generated_repo / "configs"
+    generated_config_dir.mkdir(parents=True)
+    shutil.copytree(REPO_ROOT / "data" / "raw", generated_repo / "data" / "raw")
+
+    generated_config_path = generated_config_dir / config_path.name
+    generated_config_path.write_text(
+        yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+    with _pushd(generated_repo), redirect_stdout(io.StringIO()):
+        run_command(SimpleNamespace(config=str(generated_config_path)))
+
+    generated_root = generated_repo / str(config["output_dir"])
+
+    return ArtifactSet(
+        name=config_path.stem,
+        committed_root=committed_root,
+        generated_root=generated_root,
+        strict_paths=(
+            Path("features.csv"),
+            Path("alerts.csv"),
+            Path("summary.json"),
+        ),
+        visual_snapshot_paths=(
+            Path("event_count_timeline.png"),
+            Path("error_rate_timeline.png"),
+            Path("alerts_timeline.png"),
+        ),
+    )
+
+
+def _run_demo_job(
+    job_root: Path,
+    *,
+    committed_root: Path,
+    runner: Callable[[Path], Any],
+    relative_paths: Iterable[str],
+) -> ArtifactSet:
+    generated_root = job_root / "artifacts"
+    runner(generated_root)
+    return ArtifactSet(
+        name=committed_root.parent.name,
+        committed_root=committed_root,
+        generated_root=generated_root,
+        strict_paths=tuple(Path(path) for path in relative_paths),
+    )
+
+
+def _run_ai_demo(artifacts_dir: Path) -> None:
+    from telemetry_window_demo.ai_assisted_detection_demo import default_demo_root, run_demo
+
+    run_demo(demo_root=default_demo_root(), artifacts_dir=artifacts_dir)
+
+
+def _run_rule_dedup_demo(artifacts_dir: Path) -> None:
+    from telemetry_window_demo.rule_evaluation_and_dedup_demo import (
+        default_demo_root,
+        run_demo,
+    )
+
+    run_demo(demo_root=default_demo_root(), artifacts_dir=artifacts_dir)
+
+
+def _run_config_change_demo(artifacts_dir: Path) -> None:
+    from telemetry_window_demo.config_change_investigation_demo import (
+        default_demo_root,
+        run_demo,
+    )
+
+    run_demo(demo_root=default_demo_root(), artifacts_dir=artifacts_dir)
+
+
+def _run_cloud_iam_demo(artifacts_dir: Path) -> None:
+    from telemetry_window_demo.cloud_iam_change_investigation_demo import (
+        default_demo_root,
+        run_demo,
+    )
+
+    run_demo(demo_root=default_demo_root(), artifacts_dir=artifacts_dir)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Regenerate committed demo artifacts and compare them with pipeline output.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compare regenerated artifacts with committed artifacts without modifying files.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        default=".artifact-regeneration-tmp",
+        help="Repository-relative directory used for regenerated artifacts.",
+    )
+    parser.add_argument(
+        "--no-clean",
+        dest="clean",
+        action="store_false",
+        help="Keep the temporary regeneration directory for inspection.",
+    )
+    parser.set_defaults(clean=True)
+    return parser
+
+
+def _resolve_repo_path(value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return (REPO_ROOT / path).resolve()
+
+
+def _prepare_work_root(work_root: Path) -> None:
+    work_root.mkdir(parents=True, exist_ok=True)
+    resolved = work_root.resolve()
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"work-dir must stay inside the repository: {resolved}") from exc
+
+
+def _clean_work_root(work_root: Path) -> None:
+    if not work_root.exists():
+        return
+    resolved = work_root.resolve()
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"refusing to clean work-dir outside repository: {resolved}") from exc
+    try:
+        shutil.rmtree(resolved)
+    except OSError as exc:
+        print(
+            f"[WARN] Could not remove temporary artifact directory "
+            f"{_display_path(resolved)}: {exc}",
+            file=sys.stderr,
+        )
+
+
+def _slug(value: str) -> str:
+    return "".join(char if char.isalnum() else "-" for char in value.lower()).strip("-")
+
+
+def _normalized_text(path: Path) -> str:
+    return path.read_bytes().decode("utf-8").replace("\r\n", "\n")
+
+
+@contextmanager
+def _pushd(path: Path):
+    original = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(original)
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.resolve().as_posix()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_artifact_regeneration_check.py
+++ b/tests/test_artifact_regeneration_check.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "regenerate_artifacts.py"
+
+
+def _load_regeneration_script():
+    spec = importlib.util.spec_from_file_location(
+        "regenerate_artifacts",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_regenerate_artifacts_check_matches_committed_outputs() -> None:
+    script = _load_regeneration_script()
+
+    exit_code = script.main(
+        [
+            "--check",
+            "--work-dir",
+            ".artifact-regeneration-tmp/pytest",
+            "--no-clean",
+        ]
+    )
+
+    assert exit_code == 0
+
+
+def test_regenerate_artifacts_reports_mismatched_strict_artifact(tmp_path) -> None:
+    script = _load_regeneration_script()
+    committed_root = tmp_path / "committed"
+    generated_root = tmp_path / "generated"
+    committed_root.mkdir()
+    generated_root.mkdir()
+    (committed_root / "artifact.json").write_text('{"status":"old"}\n', encoding="utf-8")
+    (generated_root / "artifact.json").write_text('{"status":"new"}\n', encoding="utf-8")
+
+    artifact_set = script.ArtifactSet(
+        name="test",
+        committed_root=committed_root,
+        generated_root=generated_root,
+        strict_paths=(Path("artifact.json"),),
+    )
+
+    differences = script.compare_artifact_set("test", artifact_set)
+
+    assert len(differences) == 1
+    assert differences[0].reason == "content differs"


### PR DESCRIPTION
Summary: Add scripts/regenerate_artifacts.py --check to regenerate demo artifacts and compare committed CSV, JSON, JSONL, and Markdown outputs with pipeline output. Visual PNG snapshots are regenerated as smoke checks without byte comparison because matplotlib output can vary by platform. Docs now point reviewers to the v1 regeneration gate. Validation: python scripts/regenerate_artifacts.py --check; python -m pytest --basetemp pytest-tmp-contract.