### PR TITLE
docs(contract): add reviewer artifact diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Latest tagged release: [v0.6.0 — fourth demo and config-change investigation](
 - [`docs/reviewer-path.md`](docs/reviewer-path.md): choose the right demo by review question
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md): demo matrix, artifact contract, and v1 readiness gate
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
+- [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md): release artifact diff contract for reviewer-facing outputs
 - [`docs/vocabulary.md`](docs/vocabulary.md): cross-demo vocabulary for events, hits, signals, bounded correlation, findings, summaries, reports, and audit traces
 - [`docs/README.md`](docs/README.md): current route, supporting docs, and historical release evidence
 
@@ -167,6 +168,7 @@ Cooldown behavior:
 - [`docs/README.md`](docs/README.md) indexes current reviewer docs, supporting design notes, and historical release evidence
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md) maps v1 evidence schemas to committed JSON artifacts
+- [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md) defines the release diff format for reviewer-facing artifact changes
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md) gives the short problem, value, evidence, and boundary summary
 - [`docs/reviewer-path.md`](docs/reviewer-path.md) maps common review questions to the right demo and artifacts
 - [`docs/architecture.md`](docs/architecture.md) diagrams the local file-based detection workflow
@@ -185,6 +187,7 @@ Cooldown behavior:
 - freeze reviewer-visible artifact names unless a rename is intentionally coordinated across docs, tests, and sample outputs
 - keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts
 - keep committed artifacts aligned with regenerated pipeline output through `python scripts/regenerate_artifacts.py --check`
+- add a reviewer-facing artifact diff for each release, using `no-artifact-change` when committed reviewer artifacts are unchanged
 - use [`docs/reviewer-pack.md`](docs/reviewer-pack.md) and [`docs/architecture.md`](docs/architecture.md) as the consolidation entrypoints
 - use the [`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate) before treating the repo as consolidated
 - avoid additional demo expansion during v1 reviewer contract stabilization

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory separates the current reviewer route from supporting design notes
 - [`reviewer-path.md`](reviewer-path.md): choose a demo by review question
 - [`reviewer-brief.md`](reviewer-brief.md): short problem, value, evidence, and boundary summary
 - [`evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
+- [`reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`vocabulary.md`](vocabulary.md): cross-demo vocabulary for evidence workflow terms and bounded correlation
 - [`architecture.md`](architecture.md): local file-based workflow diagram
 - [`roadmap.md`](roadmap.md): v1 reviewer contract stabilization phase

--- a/docs/evidence-pipeline-contract.md
+++ b/docs/evidence-pipeline-contract.md
@@ -42,3 +42,11 @@ python -m pytest tests/test_evidence_pipeline_schemas.py
 The regeneration check compares byte-stable CSV, JSON, JSONL, and Markdown artifacts with fresh pipeline output. It also regenerates PNG visual snapshots to verify that the plotting path still runs, but it does not byte-compare those images because Matplotlib rendering can vary across platforms.
 
 The schema test validates each schema file and checks that the committed artifact listed in the schema matrix conforms to it.
+
+## Release Artifact Diff
+
+Every release must include the artifact diff defined in
+[`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md). The diff must
+cover added fields, removed fields, semantic changes, and compatibility notes
+for changed reviewer artifacts, or state `no-artifact-change` when committed
+reviewer artifacts are unchanged.

--- a/docs/reviewer-artifact-diff.md
+++ b/docs/reviewer-artifact-diff.md
@@ -1,0 +1,73 @@
+# Reviewer-Facing Artifact Diff
+
+Every release must include a concise artifact diff for reviewers. The diff
+explains how committed outputs changed without asking reviewers to infer schema
+or semantic changes from raw Git diffs. If no reviewer-facing artifact changed,
+the release must say that explicitly with `no-artifact-change`.
+
+This is a release-note contract, not a production migration guide. It applies to
+the local, file-based artifacts listed in [`docs/reviewer-pack.md`](reviewer-pack.md)
+and the schema-covered evidence artifacts in
+[`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md).
+
+## Required Release Diff Sections
+
+Each release artifact diff must include:
+
+- **Added fields**: new reviewer-visible fields, columns, Markdown sections, or
+  schema properties.
+- **Removed fields**: deleted or renamed reviewer-visible fields, columns,
+  Markdown sections, or schema properties.
+- **Semantic changes**: meaning changes for existing fields, including changes
+  to ordering, grouping, correlation bounds, severity meaning, summary counts,
+  or report interpretation.
+- **Compatibility notes**: whether existing reviewer checks, example outputs,
+  schemas, or downstream inspection scripts need updates.
+
+If a release does not change reviewer-facing artifacts, state that explicitly.
+Do not leave the diff section blank.
+
+## Compatibility Labels
+
+Use one of these labels per changed artifact:
+
+| Label | Meaning |
+| --- | --- |
+| `no-artifact-change` | The release does not change reviewer-facing artifact content or meaning. |
+| `additive-compatible` | Fields or sections were added without changing existing field meaning. |
+| `semantic-change` | Existing fields remain present, but their meaning, ordering, grouping, or counting changed. |
+| `breaking-artifact-change` | Fields were removed, renamed, or changed in a way that requires reviewer docs, schemas, or checks to change. |
+| `non-contract-artifact` | The artifact is intentionally reviewer-visible but not part of the JSON schema contract. |
+
+## Template
+
+Use this table in release notes or release reviewer packs:
+
+| Artifact | Added fields | Removed fields | Semantic changes | Compatibility notes |
+| --- | --- | --- | --- | --- |
+| `path/to/artifact.json` | `field_name`, or `none` | `field_name`, or `none` | Short description, or `none` | `additive-compatible`, `semantic-change`, `breaking-artifact-change`, `no-artifact-change`, or `non-contract-artifact` |
+
+For broad changes, group related artifacts by demo but keep one row per
+reviewer-visible artifact whose shape or meaning changed.
+
+## Review Rules
+
+- Cover every changed stable reviewer-visible artifact from
+  [`docs/reviewer-pack.md`](reviewer-pack.md#stable-reviewer-visible-artifacts).
+- Cover every changed schema-covered artifact from
+  [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md#schema-matrix).
+- Include a `no-artifact-change` statement for docs-only, test-only, or
+  refactor-only releases that do not alter committed reviewer artifacts.
+- Mention artifact renames as both a removed artifact path and an added artifact
+  path, then explain compatibility.
+- Keep the language reviewer-facing: describe what changed in the evidence a
+  reviewer inspects, not internal implementation details.
+- Preserve the repo boundary: do not describe changes as SIEM, dashboard,
+  alert-routing, case-management, autonomous response, or final-verdict features.
+
+## Example
+
+| Artifact | Added fields | Removed fields | Semantic changes | Compatibility notes |
+| --- | --- | --- | --- | --- |
+| `demos/example/artifacts/example_summary.json` | `artifact_generated_at` | `none` | `none` | `additive-compatible`; reviewers can ignore the new timestamp field if they only inspect counts. |
+| `demos/example/artifacts/example_report.md` | `Compatibility notes` section | `none` | Report now separates raw evidence counts from retained findings. | `semantic-change`; reviewer docs and tests should point to the new section. |

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -35,6 +35,7 @@ The current artifact names are reviewer-facing contracts for the v1 reviewer con
 - Keep the demo matrix stable unless a demo is intentionally retired.
 - Prefer additive artifacts over renaming existing reviewer-visible outputs.
 - If an artifact must be renamed, update the README, reviewer path, this reviewer pack, demo README, tests, and committed sample outputs in the same change.
+- For each release, add the diff described in [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md), using `no-artifact-change` when reviewer-facing artifacts are unchanged.
 - Do not introduce platform-style names that imply alert routing, case management, real-time ingestion, or autonomous response.
 
 ## Evidence Pipeline Contract
@@ -74,6 +75,7 @@ Before treating the repo as v1-style consolidated:
 - Keep README, package metadata, and repository metadata aligned with the local, file-based detection workflow lab framing.
 - Run `python scripts/regenerate_artifacts.py --check` to verify committed evidence artifacts match fresh pipeline output.
 - Regenerate and inspect committed artifacts after behavior changes.
+- For every release, include a reviewer-facing artifact diff with added fields, removed fields, semantic changes, and compatibility notes, or an explicit `no-artifact-change` statement.
 - Run `pytest` and confirm reviewer-doc tests still cover the demo matrix, artifact contract, and architecture boundaries.
 - Do not add SIEM, dashboard, alert routing, case-management, real-time ingestion, autonomous response, or final-verdict claims.
 
@@ -100,6 +102,7 @@ Use the same Python interpreter for install, tests, and demo commands.
 - [`docs/reviewer-brief.md`](reviewer-brief.md): short problem / value summary
 - [`docs/reviewer-path.md`](reviewer-path.md): demo choice by review question
 - [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for selected evidence artifacts
+- [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`docs/vocabulary.md`](vocabulary.md): cross-demo evidence workflow vocabulary
 - [`docs/architecture.md`](architecture.md): local file-based workflow diagram
 - [`docs/sample-output.md`](sample-output.md): committed output counts and sample artifacts

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,7 @@ Recently added:
 - [`docs/reviewer-pack.md`](reviewer-pack.md) collects the top-level reviewer flow and artifact naming contract.
 - [`docs/architecture.md`](architecture.md) describes the local file-based workflow shape.
 - [`docs/vocabulary.md`](vocabulary.md) defines cross-demo evidence workflow terms.
+- [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md) defines the release diff contract for reviewer-facing artifact changes.
 
 ## v1 Reviewer Contract Stabilization
 
@@ -23,9 +24,10 @@ Recently added:
 3. Keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts.
 4. Keep committed evidence artifacts aligned with regenerated pipeline output.
 5. Keep cross-demo vocabulary stable for evidence workflow terms.
-6. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
-7. Keep the architecture diagram aligned with actual CLI and artifact behavior.
-8. Prefer regression tests and documentation accuracy over adding new workflow surface area.
+6. Include reviewer-facing artifact diffs in every release, including explicit `no-artifact-change` notes when committed reviewer artifacts are unchanged.
+7. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
+8. Keep the architecture diagram aligned with actual CLI and artifact behavior.
+9. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
 The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
 

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -152,6 +152,7 @@ def test_docs_index_separates_current_route_from_history() -> None:
         "reviewer-path.md",
         "reviewer-brief.md",
         "evidence-pipeline-contract.md",
+        "reviewer-artifact-diff.md",
         "vocabulary.md",
         "architecture.md",
         "roadmap.md",
@@ -185,6 +186,7 @@ def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
     assert "Artifact Naming Contract" in reviewer_pack
     assert "[`docs/README.md`](README.md)" in reviewer_pack
     assert "[`docs/reviewer-path.md`](reviewer-path.md)" in reviewer_pack
+    assert "[`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)" in reviewer_pack
     assert "[`docs/vocabulary.md`](vocabulary.md)" in reviewer_pack
     assert "[`docs/architecture.md`](architecture.md)" in reviewer_pack
     assert "[`docs/roadmap.md`](roadmap.md)" in reviewer_pack
@@ -217,6 +219,8 @@ def test_reviewer_pack_defines_v1_readiness_gate() -> None:
     assert "package metadata, and repository metadata" in reviewer_pack
     assert "Regenerate and inspect committed artifacts" in reviewer_pack
     assert "Run `pytest`" in reviewer_pack
+    assert "reviewer-facing artifact diff" in reviewer_pack
+    assert "added fields, removed fields, semantic changes, and compatibility notes" in reviewer_pack
     assert "Do not add SIEM, dashboard, alert routing" in reviewer_pack
     assert "[`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate)" in roadmap
     assert "[`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate)" in readme
@@ -276,6 +280,39 @@ def test_vocabulary_defines_cross_demo_terms() -> None:
 
     assert "[`docs/vocabulary.md`](vocabulary.md)" in roadmap
     assert "Keep cross-demo vocabulary stable" in roadmap
+
+
+def test_reviewer_artifact_diff_contract_covers_release_changes() -> None:
+    artifact_diff = _read_repo_file("docs/reviewer-artifact-diff.md")
+    docs_index = _read_repo_file("docs/README.md")
+    readme = _read_repo_file("README.md")
+    evidence_contract = _read_repo_file("docs/evidence-pipeline-contract.md")
+    roadmap = _read_repo_file("docs/roadmap.md")
+
+    assert "Every release must include a concise artifact diff" in artifact_diff
+    assert "`no-artifact-change`" in artifact_diff
+    assert "## Required Release Diff Sections" in artifact_diff
+    assert "## Compatibility Labels" in artifact_diff
+    assert "## Template" in artifact_diff
+    assert "[`docs/reviewer-pack.md`](reviewer-pack.md)" in artifact_diff
+    assert "[`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md)" in artifact_diff
+
+    for required_term in [
+        "Added fields",
+        "Removed fields",
+        "Semantic changes",
+        "Compatibility notes",
+        "no-artifact-change",
+        "additive-compatible",
+        "semantic-change",
+        "breaking-artifact-change",
+    ]:
+        assert required_term in artifact_diff
+
+    for text in [docs_index, readme, evidence_contract, roadmap]:
+        assert "reviewer-artifact-diff.md" in text
+
+    assert "Include reviewer-facing artifact diffs in every release" in roadmap
 
 
 def test_bounded_correlation_boundaries_are_documented() -> None:


### PR DESCRIPTION
Summary: Add docs/reviewer-artifact-diff.md as the release contract for reviewer-facing artifact diffs. Every release must include added fields, removed fields, semantic changes, and compatibility notes, or explicitly mark no-artifact-change when committed reviewer artifacts are unchanged. Wire the contract through README, docs index, evidence pipeline contract, reviewer pack, roadmap, and reviewer-doc regression tests. Validation: python -m pytest tests/test_reviewer_docs.py tests/test_markdown_links.py; python scripts/regenerate_artifacts.py --check; python -m pytest --basetemp pytest-tmp-contract.