### PR TITLE
docs(release): define v1 contract freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@
 
 A local, file-based detection workflow lab for reviewer-verifiable telemetry and detection demos.
 
-Current focus: v1 reviewer contract stabilization for the five-demo matrix.
+Current focus: v1 reviewer contract stabilization for the five-demo matrix, with v1.0 treated as a five-demo contract freeze.
 
 Latest tagged release: [v0.6.0 — fourth demo and config-change investigation](https://github.com/stacknil/telemetry-lab/releases/latest).
+
+Release drift note: current `main` is ahead of `v0.6.0` and contains the five-demo matrix plus v1 contract-freeze docs. Until a `v1.0` tag exists, use [`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md) and [`docs/reviewer-pack.md`](docs/reviewer-pack.md) for current main-branch review.
 
 ## Reviewer Start
 
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md): scope, value, evidence, and boundaries
 - [`docs/reviewer-path.md`](docs/reviewer-path.md): choose the right demo by review question
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md): demo matrix, artifact contract, and v1 readiness gate
+- [`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md): release artifact diff contract for reviewer-facing outputs
 - [`docs/vocabulary.md`](docs/vocabulary.md): cross-demo vocabulary for events, hits, signals, bounded correlation, findings, summaries, reports, and audit traces
@@ -167,6 +170,7 @@ Cooldown behavior:
 - [`demos/cloud-iam-change-investigation-demo/README.md`](demos/cloud-iam-change-investigation-demo/README.md) explains the synthetic CloudTrail-like IAM investigation demo and its committed artifacts
 - [`docs/README.md`](docs/README.md) indexes current reviewer docs, supporting design notes, and historical release evidence
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
+- [`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md) defines the v1.0 five-demo contract freeze gate
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md) maps v1 evidence schemas to committed JSON artifacts
 - [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md) defines the release diff format for reviewer-facing artifact changes
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md) gives the short problem, value, evidence, and boundary summary
@@ -183,6 +187,7 @@ Cooldown behavior:
 ## v1 Reviewer Contract Stabilization
 
 - demo expansion is closed
+- treat v1.0 as a five-demo contract freeze, not a feature expansion
 - stabilize the five-demo matrix and avoid broad platform expansion
 - freeze reviewer-visible artifact names unless a rename is intentionally coordinated across docs, tests, and sample outputs
 - keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory separates the current reviewer route from supporting design notes
 - [`reviewer-pack.md`](reviewer-pack.md): top-level reviewer pack, demo matrix, artifact naming contract, and v1 readiness gate
 - [`reviewer-path.md`](reviewer-path.md): choose a demo by review question
 - [`reviewer-brief.md`](reviewer-brief.md): short problem, value, evidence, and boundary summary
+- [`v1-contract-freeze.md`](v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
 - [`evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`vocabulary.md`](vocabulary.md): cross-demo vocabulary for evidence workflow terms and bounded correlation

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -69,6 +69,7 @@ The current schema contract covers:
 
 Before treating the repo as v1-style consolidated:
 
+- Use [`docs/v1-contract-freeze.md`](v1-contract-freeze.md) as the v1.0 five-demo contract freeze checklist.
 - Keep the five-demo matrix stable, or document any intentional retirement in the README, reviewer path, reviewer pack, roadmap, and tests.
 - Keep reviewer-visible artifact names stable, or update the artifact naming contract and committed sample outputs in the same change.
 - Keep `docs/reviewer-path.md`, this reviewer pack, `docs/architecture.md`, and demo READMEs aligned with actual CLI behavior.
@@ -101,6 +102,7 @@ Use the same Python interpreter for install, tests, and demo commands.
 - [`docs/README.md`](README.md): docs index for the current route, supporting docs, and historical release evidence
 - [`docs/reviewer-brief.md`](reviewer-brief.md): short problem / value summary
 - [`docs/reviewer-path.md`](reviewer-path.md): demo choice by review question
+- [`docs/v1-contract-freeze.md`](v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
 - [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for selected evidence artifacts
 - [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`docs/vocabulary.md`](vocabulary.md): cross-demo evidence workflow vocabulary

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,9 @@ Demo expansion is closed.
 
 Next phase: v1 reviewer contract stabilization.
 
-The repo now has five reviewer-verifiable demos and a clear [`docs/reviewer-path.md`](reviewer-path.md). The priority is to keep the demo matrix stable, preserve artifact names, and make review faster without implying a SIEM, dashboard, or production monitoring platform.
+The concrete milestone is [`v1.0 Five-Demo Contract Freeze`](v1-contract-freeze.md).
+
+The repo now has five reviewer-verifiable demos and a clear [`docs/reviewer-path.md`](reviewer-path.md). The priority is to keep the demo matrix stable, preserve artifact names, make release drift explicit, and make review faster without implying a SIEM, dashboard, or production monitoring platform.
 
 Recently added:
 
@@ -13,6 +15,7 @@ Recently added:
 - [cloud-iam-change-investigation-demo](../demos/cloud-iam-change-investigation-demo/README.md) now shows synthetic CloudTrail-like IAM changes, bounded cloud-control-plane signals, and a small ATT&CK mapping set.
 - [`docs/reviewer-path.md`](reviewer-path.md) maps common review questions to the right demo and artifacts.
 - [`docs/reviewer-pack.md`](reviewer-pack.md) collects the top-level reviewer flow and artifact naming contract.
+- [`docs/v1-contract-freeze.md`](v1-contract-freeze.md) defines the v1.0 five-demo contract freeze gate.
 - [`docs/architecture.md`](architecture.md) describes the local file-based workflow shape.
 - [`docs/vocabulary.md`](vocabulary.md) defines cross-demo evidence workflow terms.
 - [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md) defines the release diff contract for reviewer-facing artifact changes.
@@ -20,14 +23,15 @@ Recently added:
 ## v1 Reviewer Contract Stabilization
 
 1. Stabilize the demo matrix.
-2. Freeze reviewer-visible artifact names unless a rename is intentional and documented across README, reviewer docs, demo docs, tests, and sample outputs.
-3. Keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts.
-4. Keep committed evidence artifacts aligned with regenerated pipeline output.
-5. Keep cross-demo vocabulary stable for evidence workflow terms.
-6. Include reviewer-facing artifact diffs in every release, including explicit `no-artifact-change` notes when committed reviewer artifacts are unchanged.
-7. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
-8. Keep the architecture diagram aligned with actual CLI and artifact behavior.
-9. Prefer regression tests and documentation accuracy over adding new workflow surface area.
+2. Treat v1.0 as a five-demo contract freeze, not a feature expansion.
+3. Freeze reviewer-visible artifact names unless a rename is intentional and documented across README, reviewer docs, demo docs, tests, and sample outputs.
+4. Keep JSON schema contracts aligned with selected reviewer-facing evidence artifacts.
+5. Keep committed evidence artifacts aligned with regenerated pipeline output through `python scripts/regenerate_artifacts.py --check`.
+6. Keep cross-demo vocabulary stable for evidence workflow terms.
+7. Include reviewer-facing artifact diffs in every release, including explicit `no-artifact-change` notes when committed reviewer artifacts are unchanged.
+8. Keep one top-level reviewer pack as the primary no-guessing entrypoint.
+9. Keep the architecture diagram aligned with actual CLI and artifact behavior.
+10. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
 The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
 

--- a/docs/v1-contract-freeze.md
+++ b/docs/v1-contract-freeze.md
@@ -1,0 +1,88 @@
+# v1.0 Five-Demo Contract Freeze
+
+`telemetry-lab` is preparing a v1.0 contract freeze around the current
+five-demo matrix. This milestone is not about adding another demo or expanding
+the project into a SIEM, dashboard, or monitoring platform. It is about making
+the current local, file-based detection workflow lab reviewer-verifiable from a
+stable contract surface.
+
+## Release Drift
+
+The latest tagged release is `v0.6.0`, published as
+`v0.6.0 - fourth demo and config-change investigation`. Current `main` is ahead
+of that release: it includes the five-demo matrix, the synthetic CloudTrail-like
+IAM investigation demo, and the v1 reviewer contract stabilization docs and
+checks.
+
+Until a `v1.0` tag is created, reviewers who inspect current `main` should use
+this document, [`docs/reviewer-pack.md`](reviewer-pack.md), and
+[`docs/reviewer-path.md`](reviewer-path.md) instead of treating `v0.6.0` release
+notes as the complete current capability set.
+
+## Freeze Scope
+
+The v1.0 freeze scope is the existing five-demo matrix:
+
+1. `telemetry-window-demo`
+2. `ai-assisted-detection-demo`
+3. `rule-evaluation-and-dedup-demo`
+4. `config-change-investigation-demo`
+5. `cloud-iam-change-investigation-demo`
+
+No new demo should be added for v1.0. Any v1.0 work should improve contract
+clarity, artifact reproducibility, release notes, schema coverage, or reviewer
+navigation for this matrix.
+
+## Freeze Gate
+
+Before a v1.0 release candidate, run the following from the repository root:
+
+```bash
+python scripts/regenerate_artifacts.py --check
+python -m pytest
+```
+
+The first command is the v1.0 artifact drift gate. It regenerates the committed
+demo outputs and checks that byte-stable reviewer-facing artifacts still match
+the pipeline output. PNG timeline snapshots are regenerated as smoke checks
+without byte comparison because Matplotlib rendering can vary across platforms.
+
+The test suite then checks CLI behavior, schemas, reviewer docs, link integrity,
+time semantics, bounded correlation language, and release artifact diff
+requirements.
+
+## Contract Checklist
+
+For v1.0, keep these surfaces frozen or intentionally updated together:
+
+- five-demo matrix in the README, reviewer path, reviewer pack, roadmap, and
+  tests
+- reviewer-visible artifact names in
+  [`docs/reviewer-pack.md`](reviewer-pack.md#stable-reviewer-visible-artifacts)
+- JSON schema contracts in
+  [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md)
+- cross-demo vocabulary in [`docs/vocabulary.md`](vocabulary.md)
+- bounded correlation boundaries in [`docs/vocabulary.md`](vocabulary.md#bounded-correlation)
+- release artifact diff requirements in
+  [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)
+- committed artifact regeneration through
+  `python scripts/regenerate_artifacts.py --check`
+
+If any of these surfaces changes, update the corresponding docs, tests, and
+committed sample outputs in the same change.
+
+## Release Notes Requirement
+
+The v1.0 release notes should include:
+
+- a `no new demo` statement
+- the five-demo matrix
+- the artifact regeneration check result
+- the full test command and result
+- the reviewer-facing artifact diff required by
+  [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)
+- compatibility notes for any changed artifact shape or semantics since
+  `v0.6.0`
+
+Do not publish v1.0 as a feature expansion. Publish it as a five-demo contract
+freeze.

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -132,7 +132,9 @@ def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     assert "[`docs/reviewer-pack.md`](docs/reviewer-pack.md)" in readme
     assert "[`docs/reviewer-brief.md`](docs/reviewer-brief.md)" in readme
     assert "[`docs/reviewer-path.md`](docs/reviewer-path.md)" in readme
+    assert "[`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md)" in readme
     assert "[`docs/architecture.md`](docs/architecture.md)" in readme
+    assert "Release drift note" in readme
     assert "portfolio prototype" not in normalized
     assert "mvp only" not in normalized
 
@@ -151,6 +153,7 @@ def test_docs_index_separates_current_route_from_history() -> None:
         "reviewer-pack.md",
         "reviewer-path.md",
         "reviewer-brief.md",
+        "v1-contract-freeze.md",
         "evidence-pipeline-contract.md",
         "reviewer-artifact-diff.md",
         "vocabulary.md",
@@ -186,6 +189,7 @@ def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
     assert "Artifact Naming Contract" in reviewer_pack
     assert "[`docs/README.md`](README.md)" in reviewer_pack
     assert "[`docs/reviewer-path.md`](reviewer-path.md)" in reviewer_pack
+    assert "[`docs/v1-contract-freeze.md`](v1-contract-freeze.md)" in reviewer_pack
     assert "[`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)" in reviewer_pack
     assert "[`docs/vocabulary.md`](vocabulary.md)" in reviewer_pack
     assert "[`docs/architecture.md`](architecture.md)" in reviewer_pack
@@ -214,6 +218,7 @@ def test_reviewer_pack_defines_v1_readiness_gate() -> None:
     readme = _read_repo_file("README.md")
 
     assert "## v1 Readiness Gate" in reviewer_pack
+    assert "v1.0 five-demo contract freeze checklist" in reviewer_pack
     assert "five-demo matrix stable" in reviewer_pack
     assert "reviewer-visible artifact names stable" in reviewer_pack
     assert "package metadata, and repository metadata" in reviewer_pack
@@ -238,6 +243,7 @@ def test_current_docs_use_v1_contract_stabilization_language() -> None:
 
     assert "Demo expansion is closed." in current_docs["docs/roadmap.md"]
     assert "Next phase: v1 reviewer contract stabilization." in current_docs["docs/roadmap.md"]
+    assert "v1.0 Five-Demo Contract Freeze" in current_docs["docs/roadmap.md"]
     assert "## v1 Reviewer Contract Stabilization" in current_docs["README.md"]
 
     for path, text in current_docs.items():
@@ -313,6 +319,38 @@ def test_reviewer_artifact_diff_contract_covers_release_changes() -> None:
         assert "reviewer-artifact-diff.md" in text
 
     assert "Include reviewer-facing artifact diffs in every release" in roadmap
+
+
+def test_v1_contract_freeze_documents_release_drift_and_gate() -> None:
+    freeze_doc = _read_repo_file("docs/v1-contract-freeze.md")
+    docs_index = _read_repo_file("docs/README.md")
+    reviewer_pack = _read_repo_file("docs/reviewer-pack.md")
+    readme = _read_repo_file("README.md")
+    roadmap = _read_repo_file("docs/roadmap.md")
+
+    assert "# v1.0 Five-Demo Contract Freeze" in freeze_doc
+    assert "## Release Drift" in freeze_doc
+    assert "latest tagged release is `v0.6.0`" in freeze_doc
+    assert "Current `main` is ahead" in freeze_doc
+    assert "No new demo should be added for v1.0" in freeze_doc
+    assert "python scripts/regenerate_artifacts.py --check" in freeze_doc
+    assert "v1.0 artifact drift gate" in freeze_doc
+    assert "Do not publish v1.0 as a feature expansion" in freeze_doc
+
+    for demo_name in [
+        "telemetry-window-demo",
+        "ai-assisted-detection-demo",
+        "rule-evaluation-and-dedup-demo",
+        "config-change-investigation-demo",
+        "cloud-iam-change-investigation-demo",
+    ]:
+        assert f"`{demo_name}`" in freeze_doc
+
+    for text in [docs_index, reviewer_pack, readme, roadmap]:
+        assert "v1-contract-freeze.md" in text
+
+    assert "Release drift note" in readme
+    assert "v1.0 Five-Demo Contract Freeze" in roadmap
 
 
 def test_bounded_correlation_boundaries_are_documented() -> None:


### PR DESCRIPTION
Summary: Add docs/v1-contract-freeze.md for the v1.0 Five-Demo Contract Freeze. Document release drift from latest tagged release v0.6.0 to current main, freeze scope for the five-demo matrix, and the v1 artifact drift gate: python scripts/regenerate_artifacts.py --check. Wire the freeze doc through README, docs index, reviewer pack, roadmap, and reviewer-doc regression tests. This PR does not create a tag or GitHub Release. Validation: python -m pytest tests/test_reviewer_docs.py tests/test_markdown_links.py; python scripts/regenerate_artifacts.py --check; python -m pytest --basetemp pytest-tmp-contract.