### PR TITLE
docs(release): add v1 readiness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Release drift note: current `main` is ahead of `v0.6.0` and contains the five-de
 - [`docs/reviewer-path.md`](docs/reviewer-path.md): choose the right demo by review question
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md): demo matrix, artifact contract, and v1 readiness gate
 - [`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
+- [`docs/v1-readiness-gate.md`](docs/v1-readiness-gate.md): fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass requirements
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md): release artifact diff contract for reviewer-facing outputs
 - [`docs/vocabulary.md`](docs/vocabulary.md): cross-demo vocabulary for events, hits, signals, bounded correlation, findings, summaries, reports, and audit traces
@@ -171,6 +172,7 @@ Cooldown behavior:
 - [`docs/README.md`](docs/README.md) indexes current reviewer docs, supporting design notes, and historical release evidence
 - [`docs/reviewer-pack.md`](docs/reviewer-pack.md) is the top-level no-guessing reviewer pack and artifact naming contract
 - [`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md) defines the v1.0 five-demo contract freeze gate
+- [`docs/v1-readiness-gate.md`](docs/v1-readiness-gate.md) defines the fixed-input, fixed-output, schema-validation, artifact-regeneration, and test-pass readiness gate
 - [`docs/evidence-pipeline-contract.md`](docs/evidence-pipeline-contract.md) maps v1 evidence schemas to committed JSON artifacts
 - [`docs/reviewer-artifact-diff.md`](docs/reviewer-artifact-diff.md) defines the release diff format for reviewer-facing artifact changes
 - [`docs/reviewer-brief.md`](docs/reviewer-brief.md) gives the short problem, value, evidence, and boundary summary
@@ -194,7 +196,7 @@ Cooldown behavior:
 - keep committed artifacts aligned with regenerated pipeline output through `python scripts/regenerate_artifacts.py --check`
 - add a reviewer-facing artifact diff for each release, using `no-artifact-change` when committed reviewer artifacts are unchanged
 - use [`docs/reviewer-pack.md`](docs/reviewer-pack.md) and [`docs/architecture.md`](docs/architecture.md) as the consolidation entrypoints
-- use the [`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate) before treating the repo as consolidated
+- use the [`v1 readiness gate`](docs/v1-readiness-gate.md) before treating the repo as consolidated
 - avoid additional demo expansion during v1 reviewer contract stabilization
 
 ## Scope

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory separates the current reviewer route from supporting design notes
 - [`reviewer-path.md`](reviewer-path.md): choose a demo by review question
 - [`reviewer-brief.md`](reviewer-brief.md): short problem, value, evidence, and boundary summary
 - [`v1-contract-freeze.md`](v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
+- [`v1-readiness-gate.md`](v1-readiness-gate.md): fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass requirements
 - [`evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for reviewer-facing evidence artifacts
 - [`reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`vocabulary.md`](vocabulary.md): cross-demo vocabulary for evidence workflow terms and bounded correlation

--- a/docs/reviewer-pack.md
+++ b/docs/reviewer-pack.md
@@ -72,6 +72,7 @@ The current schema contract covers:
 Before treating the repo as v1-style consolidated:
 
 - Use [`docs/v1-contract-freeze.md`](v1-contract-freeze.md) as the v1.0 five-demo contract freeze checklist.
+- Use [`docs/v1-readiness-gate.md`](v1-readiness-gate.md) as the v1.0 readiness gate for fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass.
 - Keep the five-demo matrix stable, or document any intentional retirement in the README, reviewer path, reviewer pack, roadmap, and tests.
 - Keep reviewer-visible artifact names stable, or update the artifact naming contract and committed sample outputs in the same change.
 - Keep `docs/reviewer-path.md`, this reviewer pack, `docs/architecture.md`, and demo READMEs aligned with actual CLI behavior.
@@ -105,6 +106,7 @@ Use the same Python interpreter for install, tests, and demo commands.
 - [`docs/reviewer-brief.md`](reviewer-brief.md): short problem / value summary
 - [`docs/reviewer-path.md`](reviewer-path.md): demo choice by review question
 - [`docs/v1-contract-freeze.md`](v1-contract-freeze.md): v1.0 five-demo contract freeze and release drift note
+- [`docs/v1-readiness-gate.md`](v1-readiness-gate.md): v1.0 readiness gate for fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass
 - [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md): JSON schema contracts for five-demo evidence artifacts
 - [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md): release diff contract for reviewer-facing artifact changes
 - [`docs/vocabulary.md`](vocabulary.md): cross-demo evidence workflow vocabulary

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,7 +33,7 @@ Recently added:
 9. Keep the architecture diagram aligned with actual CLI and artifact behavior.
 10. Prefer regression tests and documentation accuracy over adding new workflow surface area.
 
-The consolidation gate lives in [`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate).
+The consolidation gate lives in [`docs/v1-readiness-gate.md`](v1-readiness-gate.md).
 
 ## Demo Expansion Closed
 

--- a/docs/v1-contract-freeze.md
+++ b/docs/v1-contract-freeze.md
@@ -35,6 +35,8 @@ navigation for this matrix.
 
 ## Freeze Gate
 
+Use [`docs/v1-readiness-gate.md`](v1-readiness-gate.md) as the release-readiness gate for fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass requirements.
+
 Before a v1.0 release candidate, run the following from the repository root:
 
 ```bash

--- a/docs/v1-readiness-gate.md
+++ b/docs/v1-readiness-gate.md
@@ -1,0 +1,87 @@
+# v1.0 Readiness Gate
+
+`telemetry-lab` is ready for v1.0 only when the current five-demo matrix is frozen, reproducible, schema-validated, and test-clean.
+
+This gate is a release-readiness checklist, not a feature roadmap. It does not authorize new demos, live ingestion, dashboards, alert routing, case management, autonomous response, or final incident verdicts.
+
+## Required Conditions
+
+v1.0 requires all of the following:
+
+1. Fixed inputs
+2. Fixed outputs
+3. Schema validation
+4. Artifact regeneration
+5. Test pass
+
+If any condition fails, v1.0 is not ready.
+
+## Fixed Inputs
+
+The committed sample inputs for the five demos are part of the reviewer contract.
+
+Before v1.0:
+
+- keep the existing five-demo matrix fixed
+- keep raw sample input paths stable unless a rename is intentionally documented across README, reviewer docs, demo docs, tests, and committed artifacts
+- keep sample inputs synthetic, local, privacy-preserving, and reviewer-verifiable
+- do not add a sixth demo or live data source for v1.0
+
+## Fixed Outputs
+
+Reviewer-visible outputs are part of the contract.
+
+Before v1.0:
+
+- keep stable artifact paths listed in [`docs/reviewer-pack.md`](reviewer-pack.md#stable-reviewer-visible-artifacts)
+- keep output semantics aligned with [`docs/evidence-pipeline-contract.md`](evidence-pipeline-contract.md)
+- document any intentional artifact shape change in [`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)
+- use `no-artifact-change` when committed reviewer artifacts are unchanged for a release
+
+## Schema Validation
+
+Reviewer-facing JSON evidence artifacts must validate against schemas under `schemas/`.
+
+Before v1.0:
+
+```bash
+python -m pytest tests/test_evidence_pipeline_schemas.py
+```
+
+This verifies that schema files are valid JSON Schema Draft 2020-12 documents and that committed JSON artifacts conform to the schema matrix.
+
+## Artifact Regeneration
+
+Committed artifacts must match fresh local pipeline output.
+
+Before v1.0:
+
+```bash
+python scripts/regenerate_artifacts.py --check
+```
+
+This is the artifact drift gate. It byte-compares stable CSV, JSON, JSONL, and Markdown artifacts and smoke-checks generated PNG timelines without byte comparison.
+
+## Test Pass
+
+The full local test suite must pass.
+
+Before v1.0:
+
+```bash
+python -m pytest
+```
+
+The suite covers CLI behavior, demo pipelines, schema validation, reviewer docs, markdown links, event-time semantics, bounded correlation language, and artifact regeneration.
+
+## Release Decision
+
+Treat the release as ready only when this exact sequence passes from the repository root:
+
+```bash
+python scripts/regenerate_artifacts.py --check
+python -m pytest tests/test_evidence_pipeline_schemas.py
+python -m pytest
+```
+
+The v1.0 release notes should include the command results and should state whether the reviewer-facing artifact diff is `no-artifact-change` or documents intentional compatibility changes.

--- a/tests/test_reviewer_docs.py
+++ b/tests/test_reviewer_docs.py
@@ -133,6 +133,7 @@ def test_readme_links_reviewer_path_and_uses_lab_framing() -> None:
     assert "[`docs/reviewer-brief.md`](docs/reviewer-brief.md)" in readme
     assert "[`docs/reviewer-path.md`](docs/reviewer-path.md)" in readme
     assert "[`docs/v1-contract-freeze.md`](docs/v1-contract-freeze.md)" in readme
+    assert "[`docs/v1-readiness-gate.md`](docs/v1-readiness-gate.md)" in readme
     assert "[`docs/architecture.md`](docs/architecture.md)" in readme
     assert "Release drift note" in readme
     assert "portfolio prototype" not in normalized
@@ -154,6 +155,7 @@ def test_docs_index_separates_current_route_from_history() -> None:
         "reviewer-path.md",
         "reviewer-brief.md",
         "v1-contract-freeze.md",
+        "v1-readiness-gate.md",
         "evidence-pipeline-contract.md",
         "reviewer-artifact-diff.md",
         "vocabulary.md",
@@ -190,6 +192,7 @@ def test_top_level_reviewer_pack_covers_matrix_and_artifact_contract() -> None:
     assert "[`docs/README.md`](README.md)" in reviewer_pack
     assert "[`docs/reviewer-path.md`](reviewer-path.md)" in reviewer_pack
     assert "[`docs/v1-contract-freeze.md`](v1-contract-freeze.md)" in reviewer_pack
+    assert "[`docs/v1-readiness-gate.md`](v1-readiness-gate.md)" in reviewer_pack
     assert "[`docs/reviewer-artifact-diff.md`](reviewer-artifact-diff.md)" in reviewer_pack
     assert "[`docs/vocabulary.md`](vocabulary.md)" in reviewer_pack
     assert "[`docs/architecture.md`](architecture.md)" in reviewer_pack
@@ -219,6 +222,7 @@ def test_reviewer_pack_defines_v1_readiness_gate() -> None:
 
     assert "## v1 Readiness Gate" in reviewer_pack
     assert "v1.0 five-demo contract freeze checklist" in reviewer_pack
+    assert "fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass" in reviewer_pack
     assert "five-demo matrix stable" in reviewer_pack
     assert "reviewer-visible artifact names stable" in reviewer_pack
     assert "package metadata, and repository metadata" in reviewer_pack
@@ -227,8 +231,8 @@ def test_reviewer_pack_defines_v1_readiness_gate() -> None:
     assert "reviewer-facing artifact diff" in reviewer_pack
     assert "added fields, removed fields, semantic changes, and compatibility notes" in reviewer_pack
     assert "Do not add SIEM, dashboard, alert routing" in reviewer_pack
-    assert "[`docs/reviewer-pack.md`](reviewer-pack.md#v1-readiness-gate)" in roadmap
-    assert "[`v1 readiness gate`](docs/reviewer-pack.md#v1-readiness-gate)" in readme
+    assert "[`docs/v1-readiness-gate.md`](v1-readiness-gate.md)" in roadmap
+    assert "[`v1 readiness gate`](docs/v1-readiness-gate.md)" in readme
 
 
 def test_current_docs_use_v1_contract_stabilization_language() -> None:
@@ -335,6 +339,7 @@ def test_v1_contract_freeze_documents_release_drift_and_gate() -> None:
     assert "No new demo should be added for v1.0" in freeze_doc
     assert "python scripts/regenerate_artifacts.py --check" in freeze_doc
     assert "v1.0 artifact drift gate" in freeze_doc
+    assert "[`docs/v1-readiness-gate.md`](v1-readiness-gate.md)" in freeze_doc
     assert "Do not publish v1.0 as a feature expansion" in freeze_doc
 
     for demo_name in [
@@ -351,6 +356,41 @@ def test_v1_contract_freeze_documents_release_drift_and_gate() -> None:
 
     assert "Release drift note" in readme
     assert "v1.0 Five-Demo Contract Freeze" in roadmap
+
+
+def test_v1_readiness_gate_defines_required_release_conditions() -> None:
+    readiness_gate = _read_repo_file("docs/v1-readiness-gate.md")
+    docs_index = _read_repo_file("docs/README.md")
+    reviewer_pack = _read_repo_file("docs/reviewer-pack.md")
+    readme = _read_repo_file("README.md")
+
+    assert "# v1.0 Readiness Gate" in readiness_gate
+    assert "If any condition fails, v1.0 is not ready." in readiness_gate
+
+    for heading in [
+        "## Fixed Inputs",
+        "## Fixed Outputs",
+        "## Schema Validation",
+        "## Artifact Regeneration",
+        "## Test Pass",
+        "## Release Decision",
+    ]:
+        assert heading in readiness_gate
+
+    for required_phrase in [
+        "Fixed inputs",
+        "Fixed outputs",
+        "Schema validation",
+        "Artifact regeneration",
+        "Test pass",
+        "python scripts/regenerate_artifacts.py --check",
+        "python -m pytest tests/test_evidence_pipeline_schemas.py",
+        "python -m pytest",
+    ]:
+        assert required_phrase in readiness_gate
+
+    for text in [docs_index, reviewer_pack, readme]:
+        assert "v1-readiness-gate.md" in text
 
 
 def test_bounded_correlation_boundaries_are_documented() -> None:


### PR DESCRIPTION
## Summary
- add docs/v1-readiness-gate.md defining v1.0 fixed inputs, fixed outputs, schema validation, artifact regeneration, and test pass requirements
- link the gate from README, docs index, reviewer pack, roadmap, and v1 contract freeze docs
- add reviewer-doc regression coverage for the new gate and links

## Validation
- pytest tests/test_reviewer_docs.py tests/test_markdown_links.py
- python scripts/regenerate_artifacts.py --check
- pytest
- git diff --check

## Safety
- docs/test-only change
- no new demo surface
- privacy scan on touched files found no account IDs, AWS key prefixes, local paths, or local usernames