### PR TITLE
chore(security): add repo sentinel adoption gate

### DIFF
--- a/.github/workflows/repo-sentinel.yml
+++ b/.github/workflows/repo-sentinel.yml
@@ -1,0 +1,37 @@
+name: Repo Sentinel
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-sentinel:
+    name: Repo Sentinel
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Install repo-sentinel-lite
+        run: |
+          python -m venv "$RUNNER_TEMP/repo-sentinel-venv"
+          "$RUNNER_TEMP/repo-sentinel-venv/bin/python" -m pip install \
+            --disable-pip-version-check \
+            repo-sentinel-lite==0.6.3
+
+      - name: Scan source, configs, and sample inputs
+        run: |
+          "$RUNNER_TEMP/repo-sentinel-venv/bin/repo-sentinel" scan \
+            --fail-on-severity error \
+            --format text \
+            .

--- a/.reposentinel.toml
+++ b/.reposentinel.toml
@@ -1,0 +1,10 @@
+# Ignore reproducible outputs while keeping source, configuration, and committed
+# sample inputs in scope for filename and high-entropy checks.
+entropy_threshold = 4.5
+
+ignore_globs = [
+  ".artifact-regeneration-tmp/**",
+  ".pytest-artifacts*/**",
+  "data/processed/**",
+  "demos/*/artifacts/**",
+]

--- a/tests/test_repo_sentinel_integration.py
+++ b/tests/test_repo_sentinel_integration.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import fnmatch
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_repo_sentinel_ignores_generated_artifacts_only() -> None:
+    with (REPO_ROOT / ".reposentinel.toml").open("rb") as config_file:
+        config = tomllib.load(config_file)
+
+    assert config["entropy_threshold"] == 4.5
+    ignore_globs = config["ignore_globs"]
+
+    assert ignore_globs == [
+        ".artifact-regeneration-tmp/**",
+        ".pytest-artifacts*/**",
+        "data/processed/**",
+        "demos/*/artifacts/**",
+    ]
+
+    in_scope_paths = [
+        "src/telemetry_window_demo/cli.py",
+        "configs/default.yaml",
+        "data/raw/sample_events.jsonl",
+        "demos/config-change-investigation-demo/config/investigation.yaml",
+        "demos/config-change-investigation-demo/data/raw/config_changes.jsonl",
+    ]
+    for path in in_scope_paths:
+        assert not any(fnmatch.fnmatchcase(path, pattern) for pattern in ignore_globs)
+
+
+def test_repo_sentinel_workflow_uses_production_package() -> None:
+    workflow = (
+        REPO_ROOT / ".github" / "workflows" / "repo-sentinel.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "repo-sentinel-lite==0.6.3" in workflow
+    assert "--fail-on-severity error" in workflow


### PR DESCRIPTION
## Summary
- add a production-PyPI repo-sentinel gate pinned to `repo-sentinel-lite==0.6.3`
- ignore reproducible output directories while keeping source, configs, and committed sample inputs in scope
- lock the intended scan boundary with integration tests

## Validation
- `python -m pytest -q` (`177 passed`)
- `python scripts/regenerate_artifacts.py --check` (`23` strict artifacts matched; `6` visual snapshots regenerated)
- `repo-sentinel scan --fail-on-severity error --format text .` (`No findings`)
- deterministic entropy probe at threshold `4.5` (`6.0000` detected)
- `git diff --check`

## Security / privacy
- no baseline or generated artifacts added
- scan output remained redacted
- workflow permissions are read-only