### PR TITLE
fix(manifest): preserve shipped config digest

### DIFF
--- a/data/processed/richer_sample/run_manifest.json
+++ b/data/processed/richer_sample/run_manifest.json
@@ -2,7 +2,7 @@
   "tool_version": "1.2.0",
   "demo_id": "window",
   "input_digest": "sha256:e8771283a83c146a2cffce5fe316c1408200b6d7717cbb6d074334aa891672f3",
-  "config_digest": "sha256:6bffef106b0fcdb04d54e3aac8fe5b4b800bf228ad03fe988861486691c76f65",
+  "config_digest": "sha256:e7cb0264262cc997edf8f6b987dc0466098f23150d0c6204fb5fd7c245df1d7d",
   "artifact_schema_versions": {
     "run_manifest": "run-manifest/v1",
     "telemetry_summary": "telemetry-summary/v1"

--- a/data/processed/run_manifest.json
+++ b/data/processed/run_manifest.json
@@ -2,7 +2,7 @@
   "tool_version": "1.2.0",
   "demo_id": "window",
   "input_digest": "sha256:c08795a6a3c361a3339414c5a8441fb74c58f027c96931dbdc0da28560e132ac",
-  "config_digest": "sha256:a6107a2a732e8f4bf03572e9e86697ce1daa0eed1871724d0b44ec677f924b37",
+  "config_digest": "sha256:b02cfeb006b05c52f075c3aa454045cd4c46b25be5576e37e184c3f02bf9328b",
   "artifact_schema_versions": {
     "run_manifest": "run-manifest/v1",
     "telemetry_summary": "telemetry-summary/v1"

--- a/scripts/regenerate_artifacts.py
+++ b/scripts/regenerate_artifacts.py
@@ -13,8 +13,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
@@ -285,10 +283,7 @@ def _run_window_pipeline_job(
     shutil.copytree(REPO_ROOT / "data" / "raw", generated_repo / "data" / "raw")
 
     generated_config_path = generated_config_dir / config_path.name
-    generated_config_path.write_text(
-        yaml.safe_dump(config, sort_keys=False),
-        encoding="utf-8",
-    )
+    shutil.copyfile(config_path, generated_config_path)
     with _pushd(generated_repo), redirect_stdout(io.StringIO()):
         run_command(SimpleNamespace(config=str(generated_config_path)))
 

--- a/tests/test_artifact_regeneration_check.py
+++ b/tests/test_artifact_regeneration_check.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
+
+from telemetry_lab.manifest import digest_files
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -35,6 +38,26 @@ def test_regenerate_artifacts_check_matches_committed_outputs() -> None:
     )
 
     assert exit_code == 0
+
+
+def test_window_regeneration_hashes_the_shipped_config_bytes(tmp_path) -> None:
+    script = _load_regeneration_script()
+    config_path = REPO_ROOT / "configs" / "default.yaml"
+
+    artifacts = script._run_window_pipeline_job(
+        tmp_path,
+        config_path=config_path,
+        committed_root=REPO_ROOT / "data" / "processed",
+    )
+    manifest = json.loads(
+        (artifacts.generated_root / "run_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert manifest["config_digest"] == digest_files(
+        {config_path.name: config_path}
+    )
 
 
 def test_regenerate_artifacts_reports_mismatched_strict_artifact(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- preserve the exact shipped YAML bytes when regenerating telemetry window artifacts
- add a regression test that compares the regenerated manifest digest with the public CLI digest
- refresh the two affected checked-in manifest digests

## Why

The v1.2.0 external clean-clone release gate exposed a reproducibility bug. `scripts/regenerate_artifacts.py` parsed and re-serialized the shipped YAML before running the pipeline, while the public CLI hashes the original file bytes. Both paths used equivalent configuration values but produced different `config_digest` identities.

## Verification

- red/green regression: the new test failed before the fix with the two distinct digests and passes after the fix
- `.venv\\Scripts\\python.exe -m pytest -q` — 190 passed
- `.venv\\Scripts\\python.exe scripts/regenerate_artifacts.py --check` — 29 strict artifacts matched; 6 visual snapshots regenerated without byte comparison
- `.venv\\Scripts\\python.exe -m build` — built the 1.2.0 wheel and source distribution
- tracked diff and privacy/secret pattern review — clean outside the four intended files

## Release decision record

- **Design decision:** copy the shipped config bytes into the isolated regeneration workspace instead of normalizing YAML through a parse/dump cycle.
- **Main risk:** callers that depended on regeneration silently normalizing YAML formatting will now retain the source formatting; no such contract is documented or tested.
- **Compatibility impact:** configuration values and CLI behavior are unchanged. Manifest identity now matches the public CLI and the shipped file.
- **Rollback path:** revert this PR and the two manifest digest updates; doing so would reintroduce the clean-clone reproduction failure.

## Release gate

This PR does not create a tag or release. After merge, the candidate must pass a fresh external clean-clone reproduction, and the new exact commit requires explicit release approval because the existing authorization names `44d755f`.
